### PR TITLE
Make the driver layer importable headless and installable cross-platform

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include pystxmcontrol/remote/remote.json

--- a/README.md
+++ b/README.md
@@ -73,6 +73,77 @@ pip install .
 - In one terminal (or Anaconda Powershell on Windows) enter: stxmserver
 - In another terminal enter: stxmcontrol
 
+# Remote GUI (stxmcontrol-remote)
+
+The `stxmcontrol-remote` console script provides a Qt-based GUI for the pystxmcontrol client wired to a Lightfall RemoteBackend, enabling remote control of STXM experiments via a running Lightfall instance with the remote-control service enabled.
+
+## Installation
+
+Install the remote-GUI extra dependencies:
+
+```
+pip install pystxmcontrol[remote]
+```
+
+This installs: `nats-py`, `tiled`, `caproto>=1.1`, and `netifaces`.
+
+## Configuration
+
+The GUI uses a JSON config file to connect to Lightfall's remote-control service via NATS. The config is loaded from a packaged default (`pystxmcontrol/remote/remote.json`) but may be overridden:
+
+```
+stxmcontrol-remote [--config /path/to/remote.json]
+```
+
+Config file structure (JSON):
+
+```json
+{
+    "nats_url": "nats://127.0.0.1:4222",
+    "prefix": "als.stxm",
+    "app_name": "pystxmcontrol-remote"
+}
+```
+
+- `nats_url`: NATS server URL (default: local NATS at port 4222)
+- `prefix`: NATS subject prefix for device/control channels (default: `als.stxm`)
+- `app_name`: Client identifier sent to Lightfall (default: `pystxmcontrol-remote`)
+
+## Prerequisites
+
+- A running Lightfall instance with the remote-control service enabled (spec #1)
+- For demo/testing: the spec #2 stxm-iocs simulator fleet running
+- Network access to the Lightfall NATS broker and Tiled server
+- Environment variable `OPHYD_CONTROL_LAYER=caproto` (set automatically by RemoteBackend)
+
+## Transport Mechanisms
+
+The remote GUI uses three separate transports for different control/monitoring needs:
+
+1. **NATS (Control):** Orchestrates scan lifecycle (plan run/abort) and manual device moves via Lightfall's capability-channel protocol
+2. **Direct CA (Motor Readback Monitoring):** Subscribes to caproto monitors for real-time motor positions without roundtrip latency
+3. **Tiled (Live Scan Images):** Streams live image data via RunStreamer for on-GUI visualization
+
+## v1 Scan-Mode Scope
+
+The initial remote GUI implementation supports:
+
+- Fly raster scans
+- Energy stack scans
+
+Other scan modes will be rejected with an `UnsupportedScanMode` error.
+
+## Disabled Features in Remote Mode
+
+The following features are disabled when controlling via the remote GUI (limitations of the remote backend or deferred to spec follow-ups):
+
+- `set_gate` (shutter control)
+- `move_to_focus` (focus-mode motions)
+- Motor configuration editing
+- `query_motor_history` (motor move logs)
+- CCD and ptychography data monitors
+- Scan-state inference from data (state is driven by explicit run lifecycle events)
+
 # Contact us
 
 For questions, bug reports, feature requests, or if you want to collaborate with us, contact dashapiro@lbl.gov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pystxmcontrol"
 version = "1.0"
 description = "Basic GUI for ALS STXM Control"
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9"
 license = "BSD-3-Clause"
 license-files = ["LICENSE.txt"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ docs = [
     "sphinx>=6.0",
     "sphinx-rtd-theme>=1.2",
 ]
+remote = [
+    "nats-py",
+    "tiled",
+    "caproto>=1.1",
+    "netifaces",
+]
 
 [project.urls]
 Homepage = "https://github.com/davidalexandershapiro/pystxmcontrol"
@@ -72,6 +78,7 @@ Repository = "https://github.com/davidalexandershapiro/pystxmcontrol.git"
 [project.scripts]
 stxmcontrol = "pystxmcontrol.gui.main:main"
 stxmserver = "pystxmcontrol.controller.server:main"
+stxmcontrol-remote = "pystxmcontrol.remote.app:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -104,3 +111,5 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/pystxmcontrol/drivers/__init__.py
+++ b/pystxmcontrol/drivers/__init__.py
@@ -1,53 +1,175 @@
-from pystxmcontrol.drivers.bcsMotor import bcsMotor
-from pystxmcontrol.drivers.nptMotor import nptMotor
-from pystxmcontrol.drivers.mmcMotor import mmcMotor
-from pystxmcontrol.drivers.epicsMotor import epicsMotor
-from pystxmcontrol.drivers.nptController import nptController
-from pystxmcontrol.drivers.bcsController import bcsController
-from pystxmcontrol.drivers.mmcController import mmcController
-from pystxmcontrol.drivers.epicsController import epicsController
-from pystxmcontrol.drivers.keysight53230A import keysight53230A
-from pystxmcontrol.drivers.keysight53230A_2channel import keysight53230A_2channel
-from pystxmcontrol.drivers.keysightU2356A import keysightU2356A
-from pystxmcontrol.drivers.fccd_control import fccd_control
-from pystxmcontrol.drivers.shutter import shutter
-from pystxmcontrol.drivers.xerMotor import xerMotor
-from pystxmcontrol.drivers.xerController import xerController
-from pystxmcontrol.drivers.derivedEnergy import derivedEnergy
-from pystxmcontrol.drivers.derivedEnergy_SGM import derivedEnergy_SGM
-from pystxmcontrol.drivers.mclController import mclController
-from pystxmcontrol.drivers.mclMotor import mclMotor
-from pystxmcontrol.drivers.derivedPiezo import derivedPiezo
-from pystxmcontrol.drivers.inclinedDerivedPiezo import inclinedDerivedPiezo
-from pystxmcontrol.drivers.inclinedSampleDerivedPiezo import inclinedSampleDerivedPiezo
-from pystxmcontrol.drivers.areaDetector import areaDetector
-from pystxmcontrol.drivers.xpsController import xpsController
-from pystxmcontrol.drivers.xpsMotor import xpsMotor
-from pystxmcontrol.drivers.E712Controller import E712Controller
-from pystxmcontrol.drivers.E712Motor import E712Motor
-from pystxmcontrol.drivers.xspress3 import xspress3
-from pystxmcontrol.drivers.zmqFrameReaderDAQ import zmq_frame_reader
+# Guard each optional driver import: a missing hardware SDK or heavy optional
+# dependency (epics, pylibftdi, scipy, matplotlib, usbtmc, h5py, SmarAct,
+# Aerotech, ...) should not prevent importing the drivers that ARE available
+# on this host. This mirrors the existing try/except pattern already used for
+# the SmarAct and Aerotech drivers below.
+
+try:
+    from pystxmcontrol.drivers.bcsMotor import bcsMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.bcsMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.nptMotor import nptMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.nptMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.mmcMotor import mmcMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.mmcMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.epicsMotor import epicsMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.epicsMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.nptController import nptController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.nptController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.bcsController import bcsController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.bcsController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.mmcController import mmcController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.mmcController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.epicsController import epicsController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.epicsController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.keysight53230A import keysight53230A
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.keysight53230A not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.keysight53230A_2channel import keysight53230A_2channel
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.keysight53230A_2channel not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.keysightU2356A import keysightU2356A
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.keysightU2356A not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.fccd_control import fccd_control
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.fccd_control not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.shutter import shutter
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.shutter not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.xerMotor import xerMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.xerMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.xerController import xerController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.xerController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.derivedEnergy import derivedEnergy
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.derivedEnergy not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.derivedEnergy_SGM import derivedEnergy_SGM
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.derivedEnergy_SGM not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.mclController import mclController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.mclController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.mclMotor import mclMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.mclMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.derivedPiezo import derivedPiezo
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.derivedPiezo not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.inclinedDerivedPiezo import inclinedDerivedPiezo
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.inclinedDerivedPiezo not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.inclinedSampleDerivedPiezo import inclinedSampleDerivedPiezo
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.inclinedSampleDerivedPiezo not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.areaDetector import areaDetector
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.areaDetector not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.xpsController import xpsController
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.xpsController not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.xpsMotor import xpsMotor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.xpsMotor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.E712Controller import E712Controller
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.E712Controller not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.E712Motor import E712Motor
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.E712Motor not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.xspress3 import xspress3
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.xspress3 not available: {_e}")
+
+try:
+    from pystxmcontrol.drivers.zmqFrameReaderDAQ import zmq_frame_reader
+except Exception as _e:
+    print(f"pystxmcontrol.drivers.zmqFrameReaderDAQ not available: {_e}")
 
 
-__all__ = ['bcsServer', 'bcsMotor', 'nptMotor', 'mmcMotor', 'epicsMotor',\
-    'nptController', 'bcsController', 'mmcController','keysight53230A','keysight53230A_2channel',\
-           'epicsController', 'shutter', 'keysightU2356A', 'fccd_control', 'xerMotor', \
-           'xerController','derivedEnergy','mclMotor', 'mclController','derivedPiezo',\
-           'areaDetector','xpsMotor','xpsController','derivedEnergy_SGM','E712Controller','E712Motor',\
-            'xspress3','inclinedDerivedPiezo','inclinedSampleDerivedPiezo','zmq_frame_reader']
+__all__ = ['bcsServer', 'bcsMotor', 'nptMotor', 'mmcMotor', 'epicsMotor',
+    'nptController', 'bcsController', 'mmcController', 'keysight53230A', 'keysight53230A_2channel',
+           'epicsController', 'shutter', 'keysightU2356A', 'fccd_control', 'xerMotor',
+           'xerController', 'derivedEnergy', 'mclMotor', 'mclController', 'derivedPiezo',
+           'areaDetector', 'xpsMotor', 'xpsController', 'derivedEnergy_SGM', 'E712Controller', 'E712Motor',
+            'xspress3', 'inclinedDerivedPiezo', 'inclinedSampleDerivedPiezo', 'zmq_frame_reader']
 
 try:
     from pystxmcontrol.drivers.mcsController import mcsController
     from pystxmcontrol.drivers.mcsMotor import mcsMotor
-except:
+except Exception:
     print("SmarAct SDK not installed.")
 else:
     __all__.append('mcsMotor')
     __all__.append('mcsController')
+
 try:
     from pystxmcontrol.drivers.aerotechController import aerotechController
     from pystxmcontrol.drivers.aerotechMotor import aerotechMotor
-except:
+except Exception:
     print("Aerotech SDK not installed.")
 else:
     __all__.append('aerotechMotor')

--- a/pystxmcontrol/gui/controllers/main_controller.py
+++ b/pystxmcontrol/gui/controllers/main_controller.py
@@ -145,6 +145,16 @@ class MainController(QObject):
         ZMQ path never touches these connections.
         """
         self.backend.auth_failed.connect(self._on_backend_auth_failed)
+        # fetch_config must not run until authentication actually completes:
+        # against a real (non-instant) LightfallClient, connect()/authenticate()
+        # really suspend on network I/O, so calling connect_and_authenticate()
+        # and fetch_config() back-to-back (as _initialize_backend_client used
+        # to) races -- fetch_config's device.search call can execute before
+        # authenticate()'s session_token is set, raising "Not authenticated"
+        # inside the backend loop and silently killing config_ready forever.
+        # Chaining off the real authenticated signal makes the ordering
+        # correct unconditionally.
+        self.backend.authenticated.connect(lambda _reply: self.backend.fetch_config())
         self.backend.config_ready.connect(self._on_backend_config_ready)
         self.backend.motor_positions.connect(self._on_backend_motor_positions)
         self.backend.scan_error.connect(self._on_backend_scan_error)
@@ -167,7 +177,8 @@ class MainController(QObject):
         """
         try:
             self.backend.connect_and_authenticate()
-            self.backend.fetch_config()
+            # fetch_config() itself is triggered by the `authenticated`
+            # signal wired in _wire_backend_signals -- see that comment.
             return True
         except Exception as e:
             self.error_occurred.emit(f"Failed to connect to server: {str(e)}")
@@ -203,7 +214,10 @@ class MainController(QObject):
         self.error_occurred.emit(message)
 
     def _on_backend_run_new(self, payload: dict):
-        run_uid = payload.get("uid")
+        # lightfall's runs.new broadcast schema is {"item_id", "run_uid",
+        # "plan_name"} (src/lightfall/remote/service.py:_register_events) --
+        # not "uid".
+        run_uid = payload.get("run_uid")
         if not run_uid or self._run_streamer is not None:
             return
         self._current_run_uid = run_uid
@@ -215,6 +229,21 @@ class MainController(QObject):
         self._run_streamer.start()
 
     def _on_backend_run_image(self, image_dict: dict, extents):
+        # RunStreamer keys image_dict by the run's actual detector/data-field
+        # name (e.g. "STXMLineFlyer" for the real pystxmcontrol flyer, or
+        # whatever data_field it was constructed with) -- not "default". The
+        # legacy image-handling branch below (_handle_monitor_message)
+        # selects image_dict[channel_key] falling back to image_dict['default'],
+        # and channel_key defaults to 'default' until the user picks a real
+        # channel from motor_info, so a remote single-detector run would
+        # otherwise never display: log a warning and silently no-op forever.
+        # Alias the sole entry under 'default' too so the existing selection
+        # logic (unchanged, still used by legacy ZMQ multi-channel scans)
+        # picks it up out of the box.
+        if "default" not in image_dict and len(image_dict) == 1:
+            image_dict = dict(image_dict)
+            image_dict["default"] = next(iter(image_dict.values()))
+
         # Synthesize the same message shape the legacy image branch of
         # _handle_monitor_message consumes: {"image": {field: ndarray},
         # "mode": <one of the recognized scan modes>, ...}.

--- a/pystxmcontrol/gui/controllers/main_controller.py
+++ b/pystxmcontrol/gui/controllers/main_controller.py
@@ -12,6 +12,7 @@ from ..models.motor_model import MotorModel
 from ..models.image_model import ImageModel
 from ...controller.client import stxm_client
 from ...utils.writeNX import stxm
+from ...remote.tiled_stream import RunStreamer
 
 
 class ControlThread(QThread):
@@ -56,20 +57,42 @@ class MainController(QObject):
     motor_scan_updated = Signal()                # single motor scan data ready to plot
     live_data_ready = Signal(object, object)     # (stxm object, raw message dict) for stack viewer
     external_scan_started = Signal(str)          # scan started externally (carries scan_type string)
-    
-    def __init__(self):
+
+    # Backend-thread -> Qt-thread bridges for RunStreamer callbacks (RunStreamer
+    # invokes on_image/on_progress/on_error from its own background poll
+    # thread; emitting a Qt signal here queues delivery onto this QObject's
+    # own thread instead of touching models cross-thread directly).
+    _run_image_ready = Signal(object, object)
+    _run_progress_ready = Signal(object, object)
+    _run_error_ready = Signal(object)
+
+    def __init__(self, backend=None):
         super().__init__()
-        
+
         # Initialize models
         self.scan_model = ScanModel()
         self.motor_model = MotorModel()
         self.image_model = ImageModel()
-        
-        # Initialize client and communication
-        self.client = stxm_client()
-        self.message_queue = Queue()
-        self.control_thread = None
-        
+
+        # Remote-GUI mode (spec #4): when a RemoteBackend is supplied, skip
+        # the legacy ZMQ client/control-thread entirely and speak to the
+        # server exclusively through the backend. backend=None (default)
+        # preserves David's local ZMQ mode untouched.
+        self.backend = backend
+        self._run_streamer = None
+        self._current_run_uid = None
+
+        if self.backend is None:
+            # Initialize client and communication
+            self.client = stxm_client()
+            self.message_queue = Queue()
+            self.control_thread = None
+        else:
+            self.client = None
+            self.message_queue = None
+            self.control_thread = None
+            self._wire_backend_signals()
+
         # State tracking
         self.scanning = False
         self.server_status = False
@@ -110,6 +133,113 @@ class MainController(QObject):
         self.scan_model.data_changed.connect(self._on_scan_model_changed)
         self.motor_model.data_changed.connect(self._on_motor_model_changed)
         self.image_model.data_changed.connect(self._on_image_model_changed)
+
+    # ------------------------------------------------------------------
+    # Remote-GUI mode (spec #4): RemoteBackend wiring
+    # ------------------------------------------------------------------
+
+    def _wire_backend_signals(self):
+        """Connect a RemoteBackend's signals to controller handlers.
+
+        Only called when a backend was supplied to __init__; the legacy
+        ZMQ path never touches these connections.
+        """
+        self.backend.auth_failed.connect(self._on_backend_auth_failed)
+        self.backend.config_ready.connect(self._on_backend_config_ready)
+        self.backend.motor_positions.connect(self._on_backend_motor_positions)
+        self.backend.scan_error.connect(self._on_backend_scan_error)
+        self.backend.remote_error.connect(self._on_backend_remote_error)
+        self.backend.run_new.connect(self._on_backend_run_new)
+        self.backend.run_complete.connect(self._on_backend_run_complete)
+        # RunStreamer callbacks arrive on a background thread; bounce them
+        # through Qt signals so the receiving slots run on this QObject's
+        # own thread before touching any model.
+        self._run_image_ready.connect(self._on_backend_run_image)
+        self._run_progress_ready.connect(self._on_backend_run_progress)
+        self._run_error_ready.connect(self._on_backend_run_error)
+
+    def _initialize_backend_client(self) -> bool:
+        """Kick off connect+auth+config fetch on the RemoteBackend.
+
+        Non-blocking: results surface later via the signals wired in
+        _wire_backend_signals (config_ready populates the motor model,
+        auth_failed reports connection failure, etc).
+        """
+        try:
+            self.backend.connect_and_authenticate()
+            self.backend.fetch_config()
+            return True
+        except Exception as e:
+            self.error_occurred.emit(f"Failed to connect to server: {str(e)}")
+            self.server_status = False
+            return False
+
+    def _on_backend_auth_failed(self, message: str):
+        self.server_status = False
+        self.error_occurred.emit(f"Authentication failed: {message}")
+
+    def _on_backend_config_ready(self, config: dict):
+        motors = config.get("motors", {})
+        # Minimal motorInfo-shaped dict: the remote device.info API only
+        # exposes {"pv", "category"} today, not hardware limits, so
+        # get_motor_limits()/get_scan_limits() fall back to their defaults
+        # (0.0/100.0) for every motor until a richer config channel exists.
+        motor_info = {name: {} for name in motors}
+        self.motor_model.set_motor_info(motor_info)
+        self.server_status = True
+        self.status_updated.emit("Connected to server")
+
+    def _on_backend_motor_positions(self, payload: dict):
+        # payload is {name: float, ..., "status": {name: bool}} -- the same
+        # shape the legacy monitor message carries under 'motorPositions'.
+        self._handle_monitor_message({"motorPositions": payload})
+
+    def _on_backend_scan_error(self, message: str):
+        self.scanning = False
+        self.error_occurred.emit(message)
+        self.scan_state_changed.emit(False)
+
+    def _on_backend_remote_error(self, message: str):
+        self.error_occurred.emit(message)
+
+    def _on_backend_run_new(self, payload: dict):
+        run_uid = payload.get("uid")
+        if not run_uid or self._run_streamer is not None:
+            return
+        self._current_run_uid = run_uid
+        self._run_streamer = RunStreamer(
+            self.backend.client.tiled_client, run_uid,
+            on_image=lambda image_dict, extents: self._run_image_ready.emit(image_dict, extents),
+            on_progress=lambda done, total: self._run_progress_ready.emit(done, total),
+            on_error=lambda exc: self._run_error_ready.emit(exc))
+        self._run_streamer.start()
+
+    def _on_backend_run_image(self, image_dict: dict, extents):
+        # Synthesize the same message shape the legacy image branch of
+        # _handle_monitor_message consumes: {"image": {field: ndarray},
+        # "mode": <one of the recognized scan modes>, ...}.
+        message = {
+            "image": image_dict,
+            "mode": "rasterLine",
+            "type": "Image",
+            "scanRegion": "Region1",
+            "energyIndex": 0,
+            "scanID": self._current_run_uid or "",
+        }
+        self._handle_monitor_message(message)
+
+    def _on_backend_run_progress(self, rows_done, rows_total):
+        self.scan_progress_updated.emit(f"{rows_done}/{rows_total}")
+
+    def _on_backend_run_error(self, exc):
+        self.error_occurred.emit(str(exc))
+
+    def _on_backend_run_complete(self, payload: dict):
+        if self._run_streamer is not None:
+            self._run_streamer.stop()
+            self._run_streamer = None
+        self._current_run_uid = None
+        self._handle_monitor_message("scan_complete")
         
     def _resolve_daq_list(self, scan_type: str) -> list:
         """
@@ -182,6 +312,8 @@ class MainController(QObject):
             
     def initialize_client(self):
         """Initialize the client connection."""
+        if self.backend is not None:
+            return self._initialize_backend_client()
         try:
             # Set up control thread
             self.control_thread = ControlThread(self.client, self.message_queue)
@@ -889,8 +1021,11 @@ class MainController(QObject):
             
         try:
             scan_config = self.scan_model.to_dict()
-            message = {"command": "scan", "scan": scan_config}
-            self.message_queue.put(message)
+            if self.backend is not None:
+                self.backend.submit_scan(scan_config)
+            else:
+                message = {"command": "scan", "scan": scan_config}
+                self.message_queue.put(message)
             self.scanning = True
             # Reset motor scan data so a new Single Motor scan starts fresh
             self.image_model._data['motor_scan_x_data'] = []
@@ -915,8 +1050,11 @@ class MainController(QObject):
     def cancel_scan(self):
         """Cancel the current scan."""
         if self.scanning:
-            message = {"command": "cancel"}
-            self.message_queue.put(message)
+            if self.backend is not None:
+                self.backend.abort_scan()
+            else:
+                message = {"command": "cancel"}
+                self.message_queue.put(message)
             self.scanning = False
             self.status_updated.emit("Scan cancelled")
             self.scan_state_changed.emit(False)  # Signal scan completed
@@ -925,21 +1063,41 @@ class MainController(QObject):
 
     def set_gate(self, mode: str):
         """Set the shutter/gate mode. mode must be 'auto', 'open', or 'closed'."""
+        if self.backend is not None:
+            self.status_updated.emit("not available in remote mode")
+            return
         self.message_queue.put({"command": "setGate", "mode": mode})
+
+    def move_to_focus(self):
+        """Move to the last calibrated focus position (legacy ZMQ mode only)."""
+        if self.backend is not None:
+            self.status_updated.emit("not available in remote mode")
+            return
+        self.client.move_to_focus()
+
+    def change_motor_config(self, motor: str, key: str, value):
+        """Change a motor configuration value on the server (legacy ZMQ mode only)."""
+        if self.backend is not None:
+            self.status_updated.emit("not available in remote mode")
+            return
+        self.client.change_motor_config(motor, key, value)
 
     def move_motor(self, motor_name: str, position: float) -> bool:
         """Move a motor to the specified position."""
         if not self.motor_model.is_scan_position_valid(motor_name, position):
             self.error_occurred.emit(f"Position {position} out of range for {motor_name}")
             return False
-            
+
         try:
-            message = {
-                "command": "moveMotor",
-                "axis": motor_name,
-                "pos": position
-            }
-            self.message_queue.put(message)
+            if self.backend is not None:
+                self.backend.move_motor(motor_name, position)
+            else:
+                message = {
+                    "command": "moveMotor",
+                    "axis": motor_name,
+                    "pos": position
+                }
+                self.message_queue.put(message)
             self.motor_model.set_target_position(motor_name, position)
             self.status_updated.emit(f"Moving {motor_name} to {position}")
             return True
@@ -1200,6 +1358,9 @@ class MainController(QObject):
         Returns a list of dicts with 'timestamp' and 'actual_position' keys,
         sorted chronologically.  Returns [] on error or if not connected.
         """
+        if self.backend is not None:
+            self.status_updated.emit("not available in remote mode")
+            return []
         try:
             response = self.client.query_motor_history(
                 motor_name, start_time, end_time, limit

--- a/pystxmcontrol/gui/controllers/main_controller.py
+++ b/pystxmcontrol/gui/controllers/main_controller.py
@@ -1377,13 +1377,30 @@ class MainController(QObject):
             return False
             
     def quit_application(self):
-        """Quit the application."""
+        """Quit the application.
+
+        sys.exit() from inside a Qt slot terminates the process immediately —
+        app.exec() never returns, so any cleanup app.py placed after it is
+        skipped. All teardown must therefore happen HERE, before sys.exit().
+        In backend (remote) mode that means stopping any live RunStreamer and
+        shutting the RemoteBackend down (which stops the CA monitor Context +
+        threads and joins the asyncio-loop thread); otherwise those threads and
+        the NATS connection are killed by raw process death instead of drained.
+        """
         self.exiting = True
         if self.control_thread:
             self.control_thread.monitor = False
             self.message_queue.put("exit")
         if self.client:
             self.client.disconnect()
+        if self._run_streamer is not None:
+            try:
+                self._run_streamer.stop()
+            except Exception:
+                pass
+            self._run_streamer = None
+        if self.backend is not None:
+            self.backend.shutdown()
         sys.exit()
         
     def get_scan_model(self) -> ScanModel:

--- a/pystxmcontrol/gui/controllers/main_controller.py
+++ b/pystxmcontrol/gui/controllers/main_controller.py
@@ -690,12 +690,16 @@ class MainController(QObject):
             self.scan_model.set('experimenters', view.ui.experimentersLineEdit.text())
             self.scan_model.set('sample', view.ui.sampleLineEdit.text())
             self.scan_model.set('comment', view.ui.commentEdit.toPlainText() if hasattr(view.ui, 'commentEdit') else '')
-            self.scan_model.set('driver', self.client.scanConfig[scan_type]['driver'])
-            self.scan_model.set('mode', self.client.scanConfig[scan_type].get('mode', 'continuousLine'))
+            # Remote-backend mode has no ZMQ client: fall back to empty
+            # configs (driver/mode/daq_list keep their model defaults).
+            scan_cfg = (getattr(self.client, 'scanConfig', None) or {}).get(scan_type, {})
+            daq_cfg = getattr(self.client, 'daqConfig', None) or {}
+            self.scan_model.set('driver', scan_cfg.get('driver', ''))
+            self.scan_model.set('mode', scan_cfg.get('mode', 'continuousLine'))
 
             # DAQ list - get from scan config but filter by what's available in daqConfig
-            if 'daq_list' in self.client.scanConfig[scan_type]:
-                daq_list_str = self.client.scanConfig[scan_type]['daq_list']
+            if 'daq_list' in scan_cfg:
+                daq_list_str = scan_cfg['daq_list']
                 if isinstance(daq_list_str, str):
                     requested_daqs = daq_list_str.split(',')
                 else:
@@ -704,8 +708,8 @@ class MainController(QObject):
                 # Filter by what's actually available and recordable in daqConfig
                 daq_list = []
                 for daq_key in requested_daqs:
-                    if daq_key in self.client.daqConfig:
-                        if self.client.daqConfig[daq_key].get('record', True):
+                    if daq_key in daq_cfg:
+                        if daq_cfg[daq_key].get('record', True):
                             daq_list.append(daq_key)
 
                 # If nothing passed the filter, use default
@@ -716,8 +720,8 @@ class MainController(QObject):
             else:
                 # Build from daqConfig - all DAQs with record=True
                 daq_list = []
-                for daq_key in self.client.daqConfig.keys():
-                    if self.client.daqConfig[daq_key].get('record', True):
+                for daq_key in daq_cfg.keys():
+                    if daq_cfg[daq_key].get('record', True):
                         daq_list.append(daq_key)
 
                 if not daq_list:

--- a/pystxmcontrol/gui/controllers/main_controller.py
+++ b/pystxmcontrol/gui/controllers/main_controller.py
@@ -659,7 +659,18 @@ class MainController(QObject):
 
         Sets the controller scanning state and emits external_scan_started so
         the view can configure itself exactly as if the user had pressed Begin.
+
+        Backend (remote) mode drives scan state exclusively from the explicit
+        run lifecycle (start_scan -> scanning=True; the run_complete broadcast
+        -> scanning=False). Inferring scan state from incoming image data races
+        that lifecycle: an image for a just-finished run, delivered right after
+        run_complete cleared the flag, would resurrect scanning=True and leave
+        it stuck. So this legacy-ZMQ inference is disabled when a backend is
+        wired. (Reflecting a scan started by another remote client is a
+        multi-operator concern deferred out of v1 scope.)
         """
+        if self.backend is not None:
+            return
         if not self.scanning and scan_type:
             self.scanning = True
             self.image_model._data['motor_scan_x_data'] = []

--- a/pystxmcontrol/gui/mainwindow_mvc.py
+++ b/pystxmcontrol/gui/mainwindow_mvc.py
@@ -110,15 +110,16 @@ class MainWindowMVC(QtWidgets.QMainWindow):
     This class is now primarily responsible for view-related operations.
     """
     
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, controller=None):
         super(MainWindowMVC, self).__init__(parent)
-        
+
         # Set up the UI
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
-        
-        # Initialize the controller
-        self.controller = MainController()
+
+        # Initialize the controller (spec #4: pass a MainController(backend=...)
+        # to run against the remote GUI instead of David's legacy ZMQ client)
+        self.controller = controller if controller is not None else MainController()
         
         # View-specific state
         self.scan_region_widgets = []

--- a/pystxmcontrol/gui/mainwindow_mvc.py
+++ b/pystxmcontrol/gui/mainwindow_mvc.py
@@ -432,8 +432,8 @@ class MainWindowMVC(QtWidgets.QMainWindow):
         self._main_scale_bar.setVisible(False)
 
         # Facility logo — filename from main_config['gui']['logo'], falls back to als-logo.png.
-        _logo_filename = (self.controller.client.main_config
-                          .get('gui', {}).get('logo', 'als-logo.png'))
+        _main_cfg = getattr(self.controller.client, 'main_config', None) or {}
+        _logo_filename = _main_cfg.get('gui', {}).get('logo', 'als-logo.png')
         _logo_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), '..', '..', 'icons', _logo_filename))
         _logo_pix = QtGui.QPixmap(_logo_path)
@@ -2575,6 +2575,12 @@ class MainWindowMVC(QtWidgets.QMainWindow):
     def _update_server_address_display(self):
         """Update the server address label, edit, and window title to reflect the connected server."""
         client = self.controller.client
+        if client is None:  # remote-backend mode: no ZMQ client to describe
+            self.ui.serverAddress.setText("remote")
+            if hasattr(self.ui, 'serverAddressEdit'):
+                self.ui.serverAddressEdit.setText("remote")
+            self.setWindowTitle("STXM Control: remote")
+            return
         address_text = f"{client.server_address}:{client.command_port}"
         self.ui.serverAddress.setText(address_text)
         if hasattr(self.ui, 'serverAddressEdit'):

--- a/pystxmcontrol/remote/__init__.py
+++ b/pystxmcontrol/remote/__init__.py
@@ -1,0 +1,18 @@
+"""Thin Lightfall remote client for the pystxmcontrol GUI (spec #4).
+
+Leaf package: NOTHING here imports lightfall, and nothing in the base
+pystxmcontrol package imports this. Install extras: pip install pystxmcontrol[remote]
+"""
+
+
+def require_remote_deps() -> None:
+    missing = []
+    for mod in ("nats", "tiled", "caproto", "netifaces"):
+        try:
+            __import__(mod)
+        except ImportError:
+            missing.append(mod)
+    if missing:
+        raise ImportError(
+            f"pystxmcontrol.remote requires {missing}; "
+            "install with: pip install pystxmcontrol[remote]")

--- a/pystxmcontrol/remote/app.py
+++ b/pystxmcontrol/remote/app.py
@@ -1,0 +1,86 @@
+"""``stxmcontrol-remote`` entry point: the pystxmcontrol GUI wired to a
+Lightfall RemoteBackend instead of David's legacy ZMQ server (spec #4 Task 7).
+
+Usage::
+
+    stxmcontrol-remote [--config path/to/remote.json]
+
+``--config`` defaults to the packaged ``remote.json`` sitting alongside this
+module: ``{"nats_url": "nats://127.0.0.1:4222", "prefix": "als.stxm",
+"app_name": "pystxmcontrol-remote"}``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from PySide6 import QtWidgets
+
+from pystxmcontrol.gui.controllers.main_controller import MainController
+from pystxmcontrol.gui.mainwindow_mvc import MainWindowMVC
+from pystxmcontrol.remote.client import LightfallClient
+from pystxmcontrol.remote.qt_bridge import RemoteBackend
+
+_DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent / "remote.json"
+
+
+def _load_config(path: str | None) -> dict:
+    config_path = Path(path) if path else _DEFAULT_CONFIG_PATH
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def _show_auth_failure_dialog(message: str) -> bool:
+    """Show a modal retry/quit dialog for an auth failure.
+
+    Returns True if the user chose Retry, False if they chose Quit.
+    """
+    box = QtWidgets.QMessageBox()
+    box.setIcon(QtWidgets.QMessageBox.Critical)
+    box.setWindowTitle("Authentication failed")
+    box.setText(f"Failed to authenticate with Lightfall:\n{message}")
+    retry_button = box.addButton("Retry", QtWidgets.QMessageBox.AcceptRole)
+    box.addButton("Quit", QtWidgets.QMessageBox.RejectRole)
+    box.exec()
+    return box.clickedButton() is retry_button
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="stxmcontrol-remote")
+    parser.add_argument(
+        "--config", default=None,
+        help="Path to a remote-GUI config JSON "
+             "(default: packaged pystxmcontrol/remote/remote.json)")
+    args = parser.parse_args(argv)
+
+    config = _load_config(args.config)
+
+    app = QtWidgets.QApplication(sys.argv[:1])
+
+    client = LightfallClient(config["nats_url"], config["prefix"], config["app_name"])
+    backend = RemoteBackend(client)
+    backend.start()
+
+    controller = MainController(backend=backend)
+
+    def _on_auth_failed(message: str) -> None:
+        if _show_auth_failure_dialog(message):
+            controller.initialize_client()
+        else:
+            backend.shutdown()
+            app.quit()
+
+    backend.auth_failed.connect(_on_auth_failed)
+
+    window = MainWindowMVC(controller=controller)
+    window.show()
+
+    exit_code = app.exec()
+    backend.shutdown()
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pystxmcontrol/remote/ca_monitors.py
+++ b/pystxmcontrol/remote/ca_monitors.py
@@ -86,6 +86,8 @@ class MotorMonitorSet:
         with self._lock:
             self._running = False
             if self._timer is not None:
+                # Intentionally drops any pending trailing flush: guaranteeing
+                # no callbacks after stop() beats delivering the last value.
                 self._timer.cancel()
                 self._timer = None
         for sub in self._subscriptions:

--- a/pystxmcontrol/remote/ca_monitors.py
+++ b/pystxmcontrol/remote/ca_monitors.py
@@ -1,0 +1,163 @@
+"""Coalesced caproto readback monitors for the remote GUI motor panel
+(spec #4 Task 4).
+
+MotorMonitorSet subscribes to ``<pv>.RBV`` and ``<pv>.MOVN`` for a set of
+motors over a single caproto threading Context, and coalesces the resulting
+callbacks into ``on_update({name: float, ..., "status": {name: bool}})``
+calls at most every ``min_period_s`` (trailing-edge flush so the final value
+always lands). No Qt here -- ``on_update`` is a plain callable; RemoteBackend
+(Task 5) adapts it to a Qt signal.
+"""
+from __future__ import annotations
+
+import functools
+import threading
+import time
+from collections.abc import Callable
+
+
+class MotorMonitorSet:
+    """CA readback monitor set for a fleet of motors.
+
+    ``motors`` maps display name -> PV prefix (e.g. ``{"SampleX":
+    "STXMSIM:E712:SampleX"}``); ``<prefix>.RBV`` and ``<prefix>.MOVN`` are
+    subscribed for each. ``connected`` reports per-motor CA connection state
+    (both RBV and MOVN connected) and drives the panel grey-out.
+    """
+
+    def __init__(self, motors: dict[str, str],
+                 on_update: Callable[[dict], None],
+                 min_period_s: float = 0.2) -> None:
+        self._motors = dict(motors)
+        self._on_update = on_update
+        self._min_period_s = min_period_s
+
+        self._lock = threading.Lock()
+        self._context = None
+        self._subscriptions: list = []
+        # caproto's CallbackHandler (both connection_state_callback and
+        # Subscription.add_callback) stores callbacks via weakref -- a
+        # functools.partial with no other strong reference is garbage
+        # collected almost immediately, silently dropping the callback. Keep
+        # every bound callback alive for the lifetime of this monitor set.
+        self._callback_refs: list = []
+
+        self._rbv_connected = {name: False for name in self._motors}
+        self._movn_connected = {name: False for name in self._motors}
+        self._connected = {name: False for name in self._motors}
+
+        self._pending_positions: dict[str, float] = {}
+        self._pending_status: dict[str, bool] = {}
+        self._last_flush = 0.0
+        self._timer: threading.Timer | None = None
+        self._running = False
+
+    @property
+    def connected(self) -> dict[str, bool]:
+        with self._lock:
+            return dict(self._connected)
+
+    def start(self) -> None:
+        from caproto.threading.client import Context
+
+        self._context = Context()
+        with self._lock:
+            self._running = True
+            self._last_flush = time.monotonic()
+
+        for name, prefix in self._motors.items():
+            conn_cb = functools.partial(self._on_connection_state, name)
+            self._callback_refs.append(conn_cb)
+            rbv_pv, movn_pv = self._context.get_pvs(
+                f"{prefix}.RBV", f"{prefix}.MOVN",
+                connection_state_callback=conn_cb)
+
+            rbv_cb = functools.partial(self._on_rbv, name)
+            movn_cb = functools.partial(self._on_movn, name)
+            self._callback_refs.extend([rbv_cb, movn_cb])
+
+            rbv_sub = rbv_pv.subscribe(data_type="time")
+            rbv_sub.add_callback(rbv_cb)
+            movn_sub = movn_pv.subscribe(data_type="time")
+            movn_sub.add_callback(movn_cb)
+            self._subscriptions.extend([rbv_sub, movn_sub])
+
+    def stop(self) -> None:
+        with self._lock:
+            self._running = False
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+        for sub in self._subscriptions:
+            sub.clear()
+        self._subscriptions = []
+        if self._context is not None:
+            self._context.disconnect()
+            self._context = None
+        self._callback_refs = []
+
+    # ---- connection state -------------------------------------------------
+
+    def _on_connection_state(self, name, pv, state) -> None:
+        connected = state == "connected"
+        is_rbv = pv.name.endswith(".RBV")
+        with self._lock:
+            if is_rbv:
+                self._rbv_connected[name] = connected
+            else:
+                self._movn_connected[name] = connected
+            self._connected[name] = (
+                self._rbv_connected.get(name, False)
+                and self._movn_connected.get(name, False))
+
+    # ---- value updates + coalescing ---------------------------------------
+
+    def _on_rbv(self, name, sub, response) -> None:
+        value = float(response.data[0])
+        self._apply_and_maybe_flush(lambda: self._pending_positions.__setitem__(
+            name, value))
+
+    def _on_movn(self, name, sub, response) -> None:
+        value = bool(response.data[0])
+        self._apply_and_maybe_flush(lambda: self._pending_status.__setitem__(
+            name, value))
+
+    def _apply_and_maybe_flush(self, apply_fn: Callable[[], None]) -> None:
+        payload = None
+        with self._lock:
+            if not self._running:
+                return
+            apply_fn()
+            now = time.monotonic()
+            elapsed = now - self._last_flush
+            if elapsed >= self._min_period_s:
+                payload = self._pop_pending_locked()
+                self._last_flush = now
+            elif self._timer is None:
+                remaining = self._min_period_s - elapsed
+                self._timer = threading.Timer(remaining, self._flush_from_timer)
+                self._timer.daemon = True
+                self._timer.start()
+        if payload is not None:
+            self._on_update(payload)
+
+    def _flush_from_timer(self) -> None:
+        payload = None
+        with self._lock:
+            self._timer = None
+            if not self._running:
+                return
+            payload = self._pop_pending_locked()
+            self._last_flush = time.monotonic()
+        if payload is not None:
+            self._on_update(payload)
+
+    def _pop_pending_locked(self) -> dict | None:
+        """Call with self._lock held."""
+        if not self._pending_positions and not self._pending_status:
+            return None
+        payload = dict(self._pending_positions)
+        payload["status"] = dict(self._pending_status)
+        self._pending_positions = {}
+        self._pending_status = {}
+        return payload

--- a/pystxmcontrol/remote/client.py
+++ b/pystxmcontrol/remote/client.py
@@ -1,0 +1,117 @@
+"""Production Lightfall remote client for the pystxmcontrol GUI (spec #4).
+
+Flow:
+    client = LightfallClient("nats://127.0.0.1:4222", "als.test", "myapp")
+    await client.connect()
+    auth = await client.authenticate()        # -> approved reply w/ session_token
+    reply = await client.call("commands.plan.list", {})
+    await client.subscribe_event("runs.new", cb)
+    await client.close()
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import nats
+
+CONTRACT_VERSION = 1
+
+
+class RemoteError(Exception):
+    """Raised when the server replies with a structured error."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(f"{code}: {message}")
+        self.code = code
+        self.message = message
+
+
+class LightfallClient:
+    """Minimal remote-control client: handshake + capability-channel calls."""
+
+    def __init__(self, nats_url: str, prefix: str, app_name: str, app_version: str = "0.0", *,
+                 _nats_connect=None) -> None:
+        self._nats_url = nats_url
+        self._prefix = prefix
+        self._app_name = app_name
+        self._app_version = app_version
+        self._nc: nats.NATS | None = None
+        self.session_token: str | None = None
+        self.tiled_url: str | None = None
+        self.tiled_token: str | None = None
+        self._nats_connect = _nats_connect
+        self._tiled = None
+
+    async def connect(self) -> None:
+        connect = self._nats_connect or nats.connect
+        self._nc = await connect(self._nats_url)
+
+    async def authenticate(self, timeout: float = 90.0) -> dict:
+        """Run the auth.request handshake; store session_token on approval.
+
+        The 90 s default outlives Lightfall's 60 s trust-dialog timeout.
+        """
+        msg = await self._nc.request(
+            f"{self._prefix}.auth.request",
+            json.dumps({"app_name": self._app_name, "app_version": self._app_version}).encode(),
+            timeout=timeout,
+        )
+        reply = json.loads(msg.data.decode())
+        if reply.get("status") == "approved":
+            self.session_token = reply["session_token"]
+            self.tiled_url = reply.get("tiled_url")
+            self.tiled_token = reply.get("tiled_token")
+        return reply
+
+    async def call(self, suffix: str, payload: dict | None = None, timeout: float = 5.0) -> dict:
+        """Request/reply on the capability channel; raise RemoteError on errors."""
+        if self.session_token is None:
+            raise RuntimeError("Not authenticated — call authenticate() first")
+        subject = f"{self._prefix}.session.{self.session_token}.{suffix}"
+        body = dict(payload or {})
+        body.setdefault("contract_version", CONTRACT_VERSION)
+        msg = await self._nc.request(subject, json.dumps(body).encode(), timeout=timeout)
+        reply = json.loads(msg.data.decode())
+        if reply.get("status") == "error":
+            raise RemoteError(reply.get("code", "unknown"), reply.get("message", ""))
+        return reply
+
+    async def call_bare(self, suffix: str, payload: dict | None = None, timeout: float = 5.0) -> dict:
+        """Request on the bare (non-channel) subject — used to prove rejection."""
+        msg = await self._nc.request(
+            f"{self._prefix}.{suffix}", json.dumps(payload or {}).encode(), timeout=timeout
+        )
+        return json.loads(msg.data.decode())
+
+    async def subscribe_event(self, suffix: str, callback: Callable[[dict], Any]) -> None:
+        """Subscribe a broadcast event (public prefixed subject)."""
+
+        async def _cb(msg) -> None:
+            callback(json.loads(msg.data.decode()))
+
+        await self._nc.subscribe(f"{self._prefix}.{suffix}", cb=_cb)
+
+    async def ping(self, timeout: float = 3.0) -> bool:
+        """Pre-trust liveness: meta.actions on the bare subject."""
+        try:
+            await self.call_bare("meta.actions", {}, timeout=timeout)
+            return True
+        except Exception:
+            return False
+
+    def tiled_client(self):
+        """Lazy tiled.client rooted at the handshake's URL/token."""
+        if not self.tiled_url:
+            raise RuntimeError("Not authenticated - no tiled_url yet")
+        if self._tiled is None:
+            from tiled.client import from_uri
+            self._tiled = from_uri(self.tiled_url, api_key=self.tiled_token)
+        return self._tiled
+
+    async def close(self) -> None:
+        if self._nc is not None:
+            await self._nc.drain()
+            self._nc = None

--- a/pystxmcontrol/remote/qt_bridge.py
+++ b/pystxmcontrol/remote/qt_bridge.py
@@ -221,15 +221,15 @@ class RemoteBackend(QtCore.QThread):
 
     async def _do_fetch_config(self) -> None:
         try:
-            search_reply = await self._client.call("device.search", {})
+            search_reply = await self._client.call("commands.device.search", {})
             device_names = search_reply.get("devices", [])
             motors: dict[str, dict] = {}
             for name in device_names:
-                info = await self._client.call("device.info", {"device": name})
+                info = await self._client.call("commands.device.info", {"device": name})
                 category = info.get("category", "")
                 if "motor" in category:
                     motors[name] = {"pv": info.get("pv"), "category": category}
-            plan_reply = await self._client.call("plan.list", {})
+            plan_reply = await self._client.call("commands.plan.list", {})
             plans = plan_reply.get("plans", [])
         except RemoteError as exc:
             self.remote_error.emit(exc.message)
@@ -268,7 +268,7 @@ class RemoteBackend(QtCore.QThread):
     async def _do_move_motor(self, name: str, position: float) -> None:
         try:
             await self._client.call(
-                "device.put", {"device": name, "value": position, "wait": True})
+                "commands.device.put", {"device": name, "value": position, "wait": True})
         except RemoteError as exc:
             self.remote_error.emit(exc.message)
 
@@ -283,7 +283,7 @@ class RemoteBackend(QtCore.QThread):
             return
         try:
             reply = await self._client.call(
-                "plan.run",
+                "commands.plan.run",
                 {"plan_name": plan_name, "params": params, "behavior": "reject"})
         except RemoteError as exc:
             self.scan_error.emit(exc.message)
@@ -292,6 +292,6 @@ class RemoteBackend(QtCore.QThread):
 
     async def _do_abort_scan(self) -> None:
         try:
-            await self._client.call("plan.abort", {})
+            await self._client.call("commands.plan.abort", {})
         except RemoteError as exc:
             self.remote_error.emit(exc.message)

--- a/pystxmcontrol/remote/qt_bridge.py
+++ b/pystxmcontrol/remote/qt_bridge.py
@@ -1,0 +1,257 @@
+"""RemoteBackend: QThread hosting an asyncio loop, bridging LightfallClient
+to Qt signals for the pystxmcontrol remote GUI (spec #4 Task 5).
+
+Usage::
+
+    client = LightfallClient(nats_url, prefix, app_name)
+    backend = RemoteBackend(client)
+    backend.authenticated.connect(...)
+    backend.start()
+    backend.connect_and_authenticate()
+    ...
+    backend.shutdown()
+    backend.wait()
+
+All public methods are thread-safe: they schedule a coroutine onto the
+backend's own asyncio loop via ``asyncio.run_coroutine_threadsafe`` and
+return immediately. Results/errors surface as Qt signals, never as
+exceptions raised back to the caller's thread.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+
+from PySide6 import QtCore
+
+from .ca_monitors import MotorMonitorSet
+from .client import RemoteError
+from .scan_mapping import UnsupportedScanMode, map_scan
+
+
+class RemoteBackend(QtCore.QThread):
+    """Asyncio<->Qt bridge around a (constructed, not-yet-connected)
+    LightfallClient.
+
+    ``monitor_factory`` defaults to :class:`MotorMonitorSet` but is
+    injectable for tests (a fake avoids any real Channel Access).
+    """
+
+    authenticated = QtCore.Signal(dict)
+    auth_failed = QtCore.Signal(str)
+    config_ready = QtCore.Signal(dict)
+    motor_positions = QtCore.Signal(dict)
+    engine_state = QtCore.Signal(str)
+    scan_submitted = QtCore.Signal(dict)
+    scan_error = QtCore.Signal(str)
+    run_new = QtCore.Signal(dict)
+    run_complete = QtCore.Signal(dict)
+    remote_error = QtCore.Signal(str)
+
+    def __init__(self, client, *, monitor_factory=MotorMonitorSet,
+                 monitor_min_period_s: float = 0.2, parent=None) -> None:
+        super().__init__(parent)
+        self._client = client
+        self._monitor_factory = monitor_factory
+        self._monitor_min_period_s = monitor_min_period_s
+        self._monitor = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_ready = QtCore.QMutex()
+        self._loop_ready_cond = QtCore.QWaitCondition()
+
+    # ------------------------------------------------------------------
+    # Thread lifecycle
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop_ready.lock()
+        self._loop = loop
+        self._loop_ready_cond.wakeAll()
+        self._loop_ready.unlock()
+        try:
+            loop.run_forever()
+        finally:
+            try:
+                pending = asyncio.all_tasks(loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True))
+            except Exception:
+                pass
+            loop.close()
+
+    def _wait_for_loop(self, timeout_ms: int = 5000) -> asyncio.AbstractEventLoop:
+        self._loop_ready.lock()
+        try:
+            deadline_remaining = timeout_ms
+            while self._loop is None and deadline_remaining > 0:
+                self._loop_ready_cond.wait(self._loop_ready, 50)
+                deadline_remaining -= 50
+        finally:
+            self._loop_ready.unlock()
+        if self._loop is None:
+            raise RuntimeError("RemoteBackend loop did not start in time")
+        return self._loop
+
+    def _schedule(self, coro) -> None:
+        """Schedule a coroutine on the backend loop from any thread."""
+        loop = self._wait_for_loop()
+
+        def _runner():
+            return asyncio.ensure_future(self._run_guarded(coro), loop=loop)
+
+        loop.call_soon_threadsafe(_runner)
+
+    async def _run_guarded(self, coro) -> None:
+        try:
+            await coro
+        except RemoteError:
+            # Individual call sites are expected to catch RemoteError
+            # themselves and emit a structured signal; if one leaks here,
+            # treat it like any other unexpected failure rather than
+            # silently swallowing it.
+            self._emit_unexpected(sys.exc_info())
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            self._emit_unexpected(sys.exc_info())
+
+    def _emit_unexpected(self, exc_info) -> None:
+        traceback.print_exception(*exc_info, file=sys.stderr)
+        self.remote_error.emit(str(exc_info[1]))
+
+    # ------------------------------------------------------------------
+    # Public thread-safe API
+    # ------------------------------------------------------------------
+
+    def connect_and_authenticate(self) -> None:
+        self._schedule(self._do_connect_and_authenticate())
+
+    def fetch_config(self) -> None:
+        self._schedule(self._do_fetch_config())
+
+    def move_motor(self, name: str, position: float) -> None:
+        self._schedule(self._do_move_motor(name, position))
+
+    def submit_scan(self, scan_dict: dict) -> None:
+        self._schedule(self._do_submit_scan(scan_dict))
+
+    def abort_scan(self) -> None:
+        self._schedule(self._do_abort_scan())
+
+    def shutdown(self) -> None:
+        if self._monitor is not None:
+            try:
+                self._monitor.stop()
+            except Exception:
+                pass
+            self._monitor = None
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            loop.call_soon_threadsafe(loop.stop)
+        self.wait(5000)
+
+    # ------------------------------------------------------------------
+    # Coroutine bodies
+    # ------------------------------------------------------------------
+
+    async def _do_connect_and_authenticate(self) -> None:
+        try:
+            await self._client.connect()
+            reply = await self._client.authenticate()
+        except RemoteError as exc:
+            self.auth_failed.emit(exc.message)
+            return
+        except Exception as exc:
+            traceback.print_exc(file=sys.stderr)
+            self.auth_failed.emit(str(exc))
+            return
+        if reply.get("status") != "approved":
+            self.auth_failed.emit(reply.get("message", "authentication rejected"))
+            return
+        await self._subscribe_broadcasts()
+        self.authenticated.emit(reply)
+
+    async def _subscribe_broadcasts(self) -> None:
+        await self._client.subscribe_event(
+            "runs.new", lambda payload: self.run_new.emit(payload))
+        await self._client.subscribe_event(
+            "runs.complete", lambda payload: self.run_complete.emit(payload))
+        await self._client.subscribe_event(
+            "state.engine",
+            lambda payload: self.engine_state.emit(payload.get("state", "")))
+
+    async def _do_fetch_config(self) -> None:
+        try:
+            search_reply = await self._client.call("device.search", {})
+            device_names = search_reply.get("devices", [])
+            motors: dict[str, dict] = {}
+            for name in device_names:
+                info = await self._client.call("device.info", {"device": name})
+                category = info.get("category", "")
+                if "motor" in category:
+                    motors[name] = {"pv": info.get("pv"), "category": category}
+            plan_reply = await self._client.call("plan.list", {})
+            plans = plan_reply.get("plans", [])
+        except RemoteError as exc:
+            self.remote_error.emit(exc.message)
+            return
+        config = {"motors": motors, "plans": plans}
+        self.config_ready.emit(config)
+        self._start_monitor(motors)
+
+    def _start_monitor(self, motors: dict[str, dict]) -> None:
+        if self._monitor is not None:
+            try:
+                self._monitor.stop()
+            except Exception:
+                pass
+            self._monitor = None
+        pv_map = {name: info["pv"] for name, info in motors.items()}
+        if not pv_map:
+            return
+        self._monitor = self._monitor_factory(
+            pv_map, self._on_monitor_update,
+            min_period_s=self._monitor_min_period_s)
+        self._monitor.start()
+
+    def _on_monitor_update(self, payload: dict) -> None:
+        # Signal emission is thread-safe from any thread (queued delivery
+        # to receivers living on another thread's event loop).
+        self.motor_positions.emit(payload)
+
+    async def _do_move_motor(self, name: str, position: float) -> None:
+        try:
+            await self._client.call(
+                "device.put", {"device": name, "value": position, "wait": True})
+        except RemoteError as exc:
+            self.remote_error.emit(exc.message)
+
+    async def _do_submit_scan(self, scan_dict: dict) -> None:
+        try:
+            plan_name, params = map_scan(scan_dict)
+        except UnsupportedScanMode as exc:
+            self.scan_error.emit(str(exc))
+            return
+        except (KeyError, ValueError) as exc:
+            self.scan_error.emit(str(exc))
+            return
+        try:
+            reply = await self._client.call(
+                "plan.run",
+                {"plan_name": plan_name, "params": params, "behavior": "reject"})
+        except RemoteError as exc:
+            self.scan_error.emit(exc.message)
+            return
+        self.scan_submitted.emit(reply)
+
+    async def _do_abort_scan(self) -> None:
+        try:
+            await self._client.call("plan.abort", {})
+        except RemoteError as exc:
+            self.remote_error.emit(exc.message)

--- a/pystxmcontrol/remote/qt_bridge.py
+++ b/pystxmcontrol/remote/qt_bridge.py
@@ -66,6 +66,11 @@ class RemoteBackend(QtCore.QThread):
         self._loop_ready = QtCore.QMutex()
         self._loop_ready_cond = QtCore.QWaitCondition()
 
+    @property
+    def client(self):
+        """The wrapped LightfallClient (read-only access for e.g. tiled_client())."""
+        return self._client
+
     # ------------------------------------------------------------------
     # Thread lifecycle
     # ------------------------------------------------------------------

--- a/pystxmcontrol/remote/qt_bridge.py
+++ b/pystxmcontrol/remote/qt_bridge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import threading
 import traceback
 
 from PySide6 import QtCore
@@ -56,6 +57,11 @@ class RemoteBackend(QtCore.QThread):
         self._monitor_factory = monitor_factory
         self._monitor_min_period_s = monitor_min_period_s
         self._monitor = None
+        # _monitor is set from the loop thread (_start_monitor) and
+        # read/cleared from the caller thread (shutdown); _shutting_down
+        # ensures no monitor starts after shutdown began.
+        self._monitor_lock = threading.Lock()
+        self._shutting_down = False
         self._loop: asyncio.AbstractEventLoop | None = None
         self._loop_ready = QtCore.QMutex()
         self._loop_ready_cond = QtCore.QWaitCondition()
@@ -144,17 +150,39 @@ class RemoteBackend(QtCore.QThread):
     def abort_scan(self) -> None:
         self._schedule(self._do_abort_scan())
 
-    def shutdown(self) -> None:
-        if self._monitor is not None:
+    def shutdown(self) -> bool:
+        """Stop the monitor set and the asyncio loop, then join the thread.
+
+        Returns True once the thread has exited. If the loop never became
+        ready or the thread refuses to die within the timeout, emits
+        remote_error and returns False (loudly, never silently).
+        """
+        with self._monitor_lock:
+            self._shutting_down = True
+            monitor, self._monitor = self._monitor, None
+        if monitor is not None:
             try:
-                self._monitor.stop()
+                monitor.stop()
             except Exception:
-                pass
-            self._monitor = None
-        loop = self._loop
-        if loop is not None and loop.is_running():
-            loop.call_soon_threadsafe(loop.stop)
-        self.wait(5000)
+                traceback.print_exc(file=sys.stderr)
+        if self.isRunning() or self._loop is not None:
+            # Wait for run() to publish the loop before scheduling its stop;
+            # reading self._loop directly races a just-started thread and
+            # would silently leave it running forever.
+            try:
+                loop = self._wait_for_loop()
+            except RuntimeError as exc:
+                if self.isRunning():
+                    self.remote_error.emit(str(exc))
+                    return False
+                return True
+            if loop.is_running():
+                loop.call_soon_threadsafe(loop.stop)
+        if not self.wait(5000):
+            self.remote_error.emit(
+                "RemoteBackend thread did not exit within 5 s of shutdown()")
+            return False
+        return True
 
     # ------------------------------------------------------------------
     # Coroutine bodies
@@ -206,19 +234,26 @@ class RemoteBackend(QtCore.QThread):
         self._start_monitor(motors)
 
     def _start_monitor(self, motors: dict[str, dict]) -> None:
-        if self._monitor is not None:
+        with self._monitor_lock:
+            old, self._monitor = self._monitor, None
+        if old is not None:
             try:
-                self._monitor.stop()
+                old.stop()
             except Exception:
-                pass
-            self._monitor = None
+                traceback.print_exc(file=sys.stderr)
         pv_map = {name: info["pv"] for name, info in motors.items()}
         if not pv_map:
             return
-        self._monitor = self._monitor_factory(
+        monitor = self._monitor_factory(
             pv_map, self._on_monitor_update,
             min_period_s=self._monitor_min_period_s)
-        self._monitor.start()
+        with self._monitor_lock:
+            if self._shutting_down:
+                # shutdown() already ran its monitor sweep; starting now
+                # would leak CA contexts/threads nobody will ever stop.
+                return
+            self._monitor = monitor
+            monitor.start()
 
     def _on_monitor_update(self, payload: dict) -> None:
         # Signal emission is thread-safe from any thread (queued delivery

--- a/pystxmcontrol/remote/remote.json
+++ b/pystxmcontrol/remote/remote.json
@@ -1,0 +1,5 @@
+{
+    "nats_url": "nats://127.0.0.1:4222",
+    "prefix": "als.stxm",
+    "app_name": "pystxmcontrol-remote"
+}

--- a/pystxmcontrol/remote/scan_mapping.py
+++ b/pystxmcontrol/remote/scan_mapping.py
@@ -36,9 +36,17 @@ class UnsupportedScanMode(ValueError):
     The offending scan_type is available as `.scan_type`.
     """
 
-    def __init__(self, scan_type: str) -> None:
+    def __init__(self, scan_type: str, message: str | None = None) -> None:
         self.scan_type = scan_type
-        super().__init__(f"unsupported scan_type: {scan_type!r}")
+        super().__init__(message or f"unsupported scan_type: {scan_type!r}")
+
+
+class MultiRegionNotSupported(UnsupportedScanMode):
+    """Raised when a scan defines more than one scan region.
+
+    The GUI genuinely supports multi-region Image scans; remote v1 does
+    not, and silently mapping only the first region would drop data.
+    """
 
 
 def _require(d: dict, key: str, context: str):
@@ -58,31 +66,39 @@ def _scan_region_params(region: dict, context: str) -> dict:
     }
 
 
-def _expand_energy_regions(energy_regions: dict) -> tuple[list[float], float]:
+def _expand_energy_regions(
+    energy_regions: dict, scan_type: str
+) -> tuple[list[float], float]:
     """Expand energy_regions into a flat, ordered energies list plus the
     dwell (ms) to use for the scan.
 
     Each region contributes ``np.linspace(start, stop, n_energies)`` (rows
     concatenate in dict-iteration order; no dedup of shared boundary
-    points — matches ScanModel.get_energies()). The first region's dwell is
-    used as the scan-wide dwell; per-region dwell is not currently mixed
-    into per-energy-point dwell (David's model has one dwell per region, not
-    per energy plans downstream want a single dwell_ms).
+    points — matches ScanModel.get_energies()). The Lightfall plans take a
+    single scan-wide dwell, but David's model allows one dwell per energy
+    region: if regions carry differing dwells we cannot honor them, so
+    that raises UnsupportedScanMode rather than silently picking one.
     """
     energies: list[float] = []
-    dwell_ms: float | None = None
+    dwells: dict[str, float] = {}
     for name, region in energy_regions.items():
         context = f"energy_regions[{name!r}]"
         start = _require(region, "start", context)
         stop = _require(region, "stop", context)
         n = _require(region, "n_energies", context)
-        dwell = _require(region, "dwell", context)
+        dwells[name] = float(_require(region, "dwell", context))
         if n < 1:
             raise ValueError(f"{context}: n_energies must be >= 1, got {n}")
         energies.extend(float(v) for v in np.linspace(start, stop, int(n)))
-        if dwell_ms is None:
-            dwell_ms = float(dwell)
-    return energies, (dwell_ms if dwell_ms is not None else 1.0)
+    unique_dwells = set(dwells.values())
+    if len(unique_dwells) > 1:
+        detail = ", ".join(f"{name}={dwell}" for name, dwell in dwells.items())
+        raise UnsupportedScanMode(
+            scan_type,
+            f"energy regions with differing dwells ({detail} ms) are not "
+            "supported; Lightfall plans take a single scan-wide dwell",
+        )
+    return energies, (unique_dwells.pop() if unique_dwells else 1.0)
 
 
 def map_scan(scan: dict) -> tuple[str, dict]:
@@ -94,12 +110,12 @@ def map_scan(scan: dict) -> tuple[str, dict]:
       - ``("stxm_energy_stack", {energies, y_start, y_stop, ny, x_start,
         x_stop, nx, dwell_ms})`` when it has more than one.
 
-    Only ``scan_type == "Image"`` is supported; a single scan region is
-    expected (the first entry of ``scan_regions`` is used — multi-region
-    Image scans are out of scope for this mapping). Any other scan_type
+    Only ``scan_type == "Image"`` with exactly one scan region is
+    supported: multi-region scans raise MultiRegionNotSupported (silently
+    mapping one region would drop the rest). Any other scan_type
     (Ptychography, Focus, Line Spectrum, Single Motor, Double Motor, ...)
-    raises UnsupportedScanMode. Missing required keys raise KeyError naming
-    the key.
+    raises UnsupportedScanMode, as do energy regions with differing dwells.
+    Missing required keys raise KeyError naming the key.
     """
     scan_type = _require(scan, "scan_type", "scan")
     if scan_type not in _SUPPORTED_SCAN_TYPES:
@@ -108,6 +124,12 @@ def map_scan(scan: dict) -> tuple[str, dict]:
     scan_regions = _require(scan, "scan_regions", "scan")
     if not scan_regions:
         raise KeyError("scan['scan_regions'] is empty")
+    if len(scan_regions) > 1:
+        raise MultiRegionNotSupported(
+            scan_type,
+            "multi-region scans not supported in remote v1; found "
+            + ", ".join(scan_regions),
+        )
     region_name = next(iter(scan_regions))
     region_params = _scan_region_params(
         scan_regions[region_name], f"scan_regions[{region_name!r}]"
@@ -116,7 +138,7 @@ def map_scan(scan: dict) -> tuple[str, dict]:
     energy_regions = _require(scan, "energy_regions", "scan")
     if not energy_regions:
         raise KeyError("scan['energy_regions'] is empty")
-    energies, dwell_ms = _expand_energy_regions(energy_regions)
+    energies, dwell_ms = _expand_energy_regions(energy_regions, scan_type)
 
     if len(energies) <= 1:
         params = dict(region_params)

--- a/pystxmcontrol/remote/scan_mapping.py
+++ b/pystxmcontrol/remote/scan_mapping.py
@@ -1,0 +1,129 @@
+"""Pure functions mapping pystxmcontrol's scan-model dict to Lightfall plan
+parameters (spec #4 Task 3).
+
+Input shape is `ScanModel.to_dict()` as populated by
+`main_controller.compile_scan_from_view` (see
+`_extract_scan_region_data` / `_extract_energy_region_data`):
+
+- ``scan['scan_regions']`` is a dict of region_name -> region dict with
+  (among others) ``xStart``/``xStop``/``xPoints`` and
+  ``yStart``/``yStop``/``yPoints`` (already center/range-derived — the GUI
+  computes Start/Stop from xCenter/xRange/xPoints before scan_regions ever
+  reaches this module, so no center/range math is needed here).
+- ``scan['energy_regions']`` is a dict of region_name -> region dict with
+  ``start``, ``stop``, ``n_energies``, and ``dwell`` (milliseconds — this is
+  the same field `ScanModel.calculate_estimated_time` divides by 1000.0 to
+  get seconds).
+
+This module is pure: no Qt, no I/O, no lightfall imports. The energy-region
+expansion (start/stop/n_energies rows -> flat eV list) mirrors
+`ScanModel.get_energies()` / the plugin's `energy_ranges.expand_ranges`
+convention, reimplemented standalone here.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+#: scan_type values this module knows how to map. Anything else —
+#: Ptychography, Focus, Line Spectrum, Single Motor, Double Motor, etc. —
+#: raises UnsupportedScanMode.
+_SUPPORTED_SCAN_TYPES = ("Image",)
+
+
+class UnsupportedScanMode(ValueError):
+    """Raised when scan['scan_type'] has no Lightfall plan mapping.
+
+    The offending scan_type is available as `.scan_type`.
+    """
+
+    def __init__(self, scan_type: str) -> None:
+        self.scan_type = scan_type
+        super().__init__(f"unsupported scan_type: {scan_type!r}")
+
+
+def _require(d: dict, key: str, context: str):
+    if key not in d:
+        raise KeyError(f"{context} missing required key {key!r}")
+    return d[key]
+
+
+def _scan_region_params(region: dict, context: str) -> dict:
+    return {
+        "y_start": float(_require(region, "yStart", context)),
+        "y_stop": float(_require(region, "yStop", context)),
+        "ny": int(_require(region, "yPoints", context)),
+        "x_start": float(_require(region, "xStart", context)),
+        "x_stop": float(_require(region, "xStop", context)),
+        "nx": int(_require(region, "xPoints", context)),
+    }
+
+
+def _expand_energy_regions(energy_regions: dict) -> tuple[list[float], float]:
+    """Expand energy_regions into a flat, ordered energies list plus the
+    dwell (ms) to use for the scan.
+
+    Each region contributes ``np.linspace(start, stop, n_energies)`` (rows
+    concatenate in dict-iteration order; no dedup of shared boundary
+    points — matches ScanModel.get_energies()). The first region's dwell is
+    used as the scan-wide dwell; per-region dwell is not currently mixed
+    into per-energy-point dwell (David's model has one dwell per region, not
+    per energy plans downstream want a single dwell_ms).
+    """
+    energies: list[float] = []
+    dwell_ms: float | None = None
+    for name, region in energy_regions.items():
+        context = f"energy_regions[{name!r}]"
+        start = _require(region, "start", context)
+        stop = _require(region, "stop", context)
+        n = _require(region, "n_energies", context)
+        dwell = _require(region, "dwell", context)
+        if n < 1:
+            raise ValueError(f"{context}: n_energies must be >= 1, got {n}")
+        energies.extend(float(v) for v in np.linspace(start, stop, int(n)))
+        if dwell_ms is None:
+            dwell_ms = float(dwell)
+    return energies, (dwell_ms if dwell_ms is not None else 1.0)
+
+
+def map_scan(scan: dict) -> tuple[str, dict]:
+    """Map a pystxmcontrol scan-model dict to a (plan_name, plan_kwargs) pair.
+
+    Returns either:
+      - ``("stxm_fly_raster", {y_start, y_stop, ny, x_start, x_stop, nx, dwell})``
+        when the scan has exactly one (expanded) energy point, or
+      - ``("stxm_energy_stack", {energies, y_start, y_stop, ny, x_start,
+        x_stop, nx, dwell_ms})`` when it has more than one.
+
+    Only ``scan_type == "Image"`` is supported; a single scan region is
+    expected (the first entry of ``scan_regions`` is used — multi-region
+    Image scans are out of scope for this mapping). Any other scan_type
+    (Ptychography, Focus, Line Spectrum, Single Motor, Double Motor, ...)
+    raises UnsupportedScanMode. Missing required keys raise KeyError naming
+    the key.
+    """
+    scan_type = _require(scan, "scan_type", "scan")
+    if scan_type not in _SUPPORTED_SCAN_TYPES:
+        raise UnsupportedScanMode(scan_type)
+
+    scan_regions = _require(scan, "scan_regions", "scan")
+    if not scan_regions:
+        raise KeyError("scan['scan_regions'] is empty")
+    region_name = next(iter(scan_regions))
+    region_params = _scan_region_params(
+        scan_regions[region_name], f"scan_regions[{region_name!r}]"
+    )
+
+    energy_regions = _require(scan, "energy_regions", "scan")
+    if not energy_regions:
+        raise KeyError("scan['energy_regions'] is empty")
+    energies, dwell_ms = _expand_energy_regions(energy_regions)
+
+    if len(energies) <= 1:
+        params = dict(region_params)
+        params["dwell"] = dwell_ms
+        return "stxm_fly_raster", params
+
+    params = dict(region_params)
+    params["energies"] = energies
+    params["dwell_ms"] = dwell_ms
+    return "stxm_energy_stack", params

--- a/pystxmcontrol/remote/tiled_stream.py
+++ b/pystxmcontrol/remote/tiled_stream.py
@@ -1,0 +1,202 @@
+"""RunStreamer: poll a Tiled STXM run's primary stream into live image
+payloads (spec #4 Task 6).
+
+Run-layout rules transcribed from ``lightfall_pystxmcontrol/contract.py`` and
+the read-side of ``lightfall_pystxmcontrol/stxm_map_viz.py`` (this module
+imports NOTHING from that plugin package -- it only mirrors the layout):
+
+- **Fly-raster runs** (``plans.py: stxm_fly_raster``) put ``shape: [ny, nx]``
+  and ``x_extent``/``y_extent`` directly at the top level of the start doc
+  (``run.metadata["start"]``). There is no ``stxm`` block. Row *r* (0-based,
+  == the number of primary-stream table rows written so far, minus one) maps
+  straight onto image row *r*.
+- **Energy-stack runs** (``plans.py: stxm_energy_stack`` /
+  ``contract.stxm_start_md``) nest ``shape: [nE, ny, nx]`` and
+  ``x_extent``/``y_extent`` under ``start["stxm"]``. Row ordering follows
+  ``contract.decode_line_index``: ``seq_num = iE*ny + iy + 1``, i.e. row *r*
+  (0-based) decodes to ``iE, iy = divmod(r, ny)`` (transcribed here, not
+  imported). v1 policy (this task): show the CURRENT energy slice only --
+  the image is (ny, nx), each row's value coming from the highest ``iE``
+  that has any data, rows within that slice indexed by ``iy``. This matches
+  the "rows modulo ny" framing in the task brief and keeps the widget a
+  plain 2-D map for both run kinds.
+- Either way, ``run["primary"]`` is the stream node and **must** be read via
+  its table facet (``stream.read()``), never a scalar column facet (Tiled
+  gotcha: scalar facets 500/hang under concurrent writer appends). The table
+  is a mapping of column name -> sequence, one entry per line-event row;
+  ``data_field`` (default ``"Counter1"``) is the per-row length-``nx`` array
+  column blitted into the image.
+
+RunStreamer runs this poll on a background thread: pure Python, no Qt, no
+lightfall imports. Tiled client objects arrive via ``tiled_client_factory``
+and are used duck-typed (``factory() -> catalog``, ``catalog[run_uid] ->
+run``, ``run["primary"] -> stream node``).
+"""
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+
+
+class RunStreamer:
+    """Background-thread poller: Tiled run primary stream -> live 2-D image.
+
+    Args:
+        tiled_client_factory: ``() -> catalog``-like object (e.g.
+            ``LightfallClient.tiled_client()``); called once at ``start()``
+            time on the background thread so a slow/failed Tiled connection
+            never blocks the caller. ``catalog[run_uid]`` yields the run.
+        run_uid: catalog key for the run (``catalog[run_uid]``).
+        on_image: ``({data_field: ndarray(ny, nx)}, (x_extent, y_extent))``,
+            invoked whenever the polled table has grown.
+        on_progress: ``(rows_done, rows_total)``, invoked on every poll.
+        on_error: ``(exc)``, invoked exactly once on the first failure
+            (missing/malformed stream, bad metadata, factory/catalog errors);
+            the poll loop then stops cleanly, never crashing the thread.
+        poll_s: seconds between polls.
+        data_field: table column blitted into the image.
+    """
+
+    def __init__(self, tiled_client_factory: Callable[[], Any], run_uid: str,
+                 on_image: Callable[[dict, tuple], None],
+                 on_progress: Callable[[int, int], None], *,
+                 on_error: Callable[[BaseException], None] | None = None,
+                 poll_s: float = 1.0, data_field: str = "Counter1") -> None:
+        self._factory = tiled_client_factory
+        self._run_uid = run_uid
+        self._on_image = on_image
+        self._on_progress = on_progress
+        self._on_error = on_error
+        self._poll_s = poll_s
+        self._data_field = data_field
+
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._rows_done = 0
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=self._poll_s + 2.0)
+
+    # ------------------------------------------------------------------
+    # Poll loop
+    # ------------------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        try:
+            catalog = self._factory()
+            run = catalog[self._run_uid]
+            layout = self._resolve_layout(run)
+        except Exception as exc:  # noqa: BLE001 - report, never crash
+            self._report_error(exc)
+            return
+
+        while not self._stop_event.is_set():
+            try:
+                self._poll_once(run, layout)
+            except Exception as exc:  # noqa: BLE001 - report, never crash
+                self._report_error(exc)
+                return
+            self._stop_event.wait(self._poll_s)
+
+    def _poll_once(self, run: Any, layout: "_Layout") -> None:
+        stream = run["primary"]
+        table = stream.read()
+        column = table[self._data_field]
+        rows_done = len(column)
+        self._rows_done = rows_done
+
+        image = _assemble_image(column, layout)
+        self._on_image({self._data_field: image},
+                        (layout.x_extent, layout.y_extent))
+        self._on_progress(rows_done, layout.rows_total)
+
+    def _report_error(self, exc: BaseException) -> None:
+        if self._on_error is not None:
+            self._on_error(exc)
+
+    @staticmethod
+    def _resolve_layout(run: Any) -> "_Layout":
+        start = run.metadata["start"]
+        stxm = start.get("stxm")
+        if isinstance(stxm, dict):
+            nE, ny, nx = (int(v) for v in stxm["shape"])
+            return _Layout(ny=ny, nx=nx, n_energies=nE,
+                            x_extent=list(stxm["x_extent"]),
+                            y_extent=list(stxm["y_extent"]))
+        ny, nx = (int(v) for v in start["shape"])
+        return _Layout(ny=ny, nx=nx, n_energies=1,
+                        x_extent=list(start["x_extent"]),
+                        y_extent=list(start["y_extent"]))
+
+
+class _Layout:
+    """Resolved (ny, nx[, nE]) shape + extents for one run."""
+
+    __slots__ = ("ny", "nx", "n_energies", "x_extent", "y_extent")
+
+    def __init__(self, *, ny: int, nx: int, n_energies: int,
+                 x_extent: list, y_extent: list) -> None:
+        self.ny = ny
+        self.nx = nx
+        self.n_energies = n_energies
+        self.x_extent = x_extent
+        self.y_extent = y_extent
+
+    @property
+    def rows_total(self) -> int:
+        return self.n_energies * self.ny
+
+
+def _assemble_image(column: Any, layout: "_Layout") -> np.ndarray:
+    """Build the (ny, nx) NaN-filled image for the current display slice.
+
+    Single-energy (raster) runs: row *r* -> image row *r* directly.
+    Multi-energy (stack) runs: rows decode via ``iE, iy = divmod(r, ny)``
+    (contract.decode_line_index's rule, transcribed); v1 shows only the
+    slice containing the most-recently-written row (the CURRENT energy),
+    each row within that slice placed at ``iy``.
+    """
+    ny, nx = layout.ny, layout.nx
+    image = np.full((ny, nx), np.nan, dtype=float)
+    n_rows = len(column)
+    if n_rows == 0:
+        return image
+
+    if layout.n_energies <= 1:
+        rows = column[:ny]
+        for r, line in enumerate(rows):
+            _blit_row(image, r, line, nx)
+        return image
+
+    current_row = n_rows - 1
+    current_iE, _ = divmod(current_row, ny)
+    slice_start = current_iE * ny
+    slice_end = slice_start + ny
+    for r in range(slice_start, min(slice_end, n_rows)):
+        _, iy = divmod(r, ny)
+        _blit_row(image, iy, column[r], nx)
+    return image
+
+
+def _blit_row(image: np.ndarray, row: int, line: Any, nx: int) -> None:
+    arr = np.asarray(line, dtype=float)
+    if arr.shape != (nx,):
+        raise ValueError(
+            f"row {row}: expected a length-{nx} line, got shape {arr.shape}")
+    image[row] = arr

--- a/pystxmcontrol/remote/tiled_stream.py
+++ b/pystxmcontrol/remote/tiled_stream.py
@@ -37,9 +37,31 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as _FutureTimeoutError
 from typing import Any
 
 import numpy as np
+
+
+def _call_with_timeout(fn: Callable[[], Any], *, timeout_s: float) -> Any:
+    """Run ``fn()`` on a helper thread and raise ``TimeoutError`` if it
+    doesn't return within ``timeout_s`` -- turns a client-library stall
+    (no exception, no response, ever) into something the caller can treat
+    as an ordinary poll failure instead of hanging forever."""
+    # NOT a context manager: Executor.__exit__ calls shutdown(wait=True),
+    # which would block on the very stall this helper exists to escape.
+    # The one worker thread is leaked (daemon-equivalent: process exit
+    # doesn't wait on it) if fn() never returns; that's the accepted
+    # trade-off for never hanging the poll loop itself.
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(fn)
+    try:
+        return future.result(timeout=timeout_s)
+    except _FutureTimeoutError as exc:
+        raise TimeoutError(
+            f"{fn!r} did not complete within {timeout_s}s") from exc
+    finally:
+        executor.shutdown(wait=False)
 
 
 class RunStreamer:
@@ -65,7 +87,7 @@ class RunStreamer:
                  on_image: Callable[[dict, tuple], None],
                  on_progress: Callable[[int, int], None], *,
                  on_error: Callable[[BaseException], None] | None = None,
-                 poll_s: float = 1.0, data_field: str = "Counter1") -> None:
+                 poll_s: float = 1.0, data_field: str | None = None) -> None:
         self._factory = tiled_client_factory
         self._run_uid = run_uid
         self._on_image = on_image
@@ -77,6 +99,7 @@ class RunStreamer:
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
         self._rows_done = 0
+        self._failing_since: float | None = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -102,21 +125,65 @@ class RunStreamer:
             catalog = self._factory()
             run = catalog[self._run_uid]
             layout = self._resolve_layout(run)
+            if self._data_field is None:
+                # No explicit column configured: derive it from the start
+                # doc's ``detectors`` list (plans.py always sets exactly one
+                # entry to the flying detector's ophyd .name, which is the
+                # primary-stream column key -- see stxm_fly_raster/
+                # stxm_energy_stack in lightfall_pystxmcontrol/plans.py).
+                # Falls back to "Counter1" only if the start doc carries no
+                # detectors metadata at all (defensive, should not happen).
+                detectors = run.metadata["start"].get("detectors") or []
+                self._data_field = detectors[0] if detectors else "Counter1"
         except Exception as exc:  # noqa: BLE001 - report, never crash
             self._report_error(exc)
             return
 
+        # Tolerate a bounded run of transient poll failures rather than
+        # reporting on the first one. RunStreamer starts as soon as the
+        # "runs.new" broadcast fires (the run's "start" doc), but the
+        # "primary" stream container is only created moments later,
+        # server-side, on the first descriptor doc from the plan's first
+        # row -- so an initial GET of "primary" can race its own concurrent
+        # creation. Against a real Tiled HTTP server this has been observed
+        # to surface as more than one transient error in a row (not just a
+        # single 404 on the very first poll): the in-process writer's own
+        # subsequent metadata calls for that run can also spuriously 500
+        # while the race resolves. ``_failing_since`` tracks how long
+        # polling has been continuously failing (reset to None on any
+        # success) so a real, permanent failure (stream never appears,
+        # malformed table, ...) still gets reported -- just not before a
+        # grace window has elapsed.
+        self._failing_since: float | None = None
+        grace_s = max(0.5, self._poll_s * 10)
+
         while not self._stop_event.is_set():
             try:
                 self._poll_once(run, layout)
+                self._failing_since = None
             except Exception as exc:  # noqa: BLE001 - report, never crash
+                now = time.monotonic()
+                if self._failing_since is None:
+                    self._failing_since = now
+                if now - self._failing_since < grace_s:
+                    self._stop_event.wait(min(self._poll_s, 0.5))
+                    continue
                 self._report_error(exc)
                 return
             self._stop_event.wait(self._poll_s)
 
     def _poll_once(self, run: Any, layout: "_Layout") -> None:
-        stream = run["primary"]
-        table = stream.read()
+        # A real Tiled HTTP client can, under concurrent read/write load,
+        # stall well beyond any sane poll interval instead of raising
+        # (observed in the live-service e2e harness: no exception, no
+        # server-side request even logged -- consistent with a client-side
+        # connection-pool wait that never resolves). This can happen on
+        # EITHER the "primary" node lookup or the subsequent read, so both
+        # run on a watchdog thread: a stall becomes a TimeoutError that
+        # flows through the normal grace-period retry/report path instead
+        # of wedging this poll thread forever with no error ever reported.
+        table = _call_with_timeout(
+            lambda: run["primary"].read(), timeout_s=20.0)
         column = table[self._data_field]
         rows_done = len(column)
         self._rows_done = rows_done

--- a/setup.py
+++ b/setup.py
@@ -61,12 +61,15 @@ setup(  name = 'pystxmcontrol',
         author = 'David Shapiro',
         author_email = 'dashapiro@lbl.gov',
         packages = ['pystxmcontrol','pystxmcontrol.gui','pystxmcontrol.controller',\
-            'pystxmcontrol.drivers','pystxmcontrol.utils','pystxmcontrol.controller.scans'],
+            'pystxmcontrol.drivers','pystxmcontrol.utils','pystxmcontrol.controller.scans',\
+            'pystxmcontrol.remote'],
+        package_data = {'pystxmcontrol.remote': ['remote.json']},
         entry_points = {
             'console_scripts': [
                 'stxmcontrol = pystxmcontrol.gui.main:main',
                 'stxmserver   = pystxmcontrol.controller.server:main',
                 'stxmbrowser  = pystxmcontrol.gui.browser_analysis_app:main',
+                'stxmcontrol-remote = pystxmcontrol.remote.app:main',
             ],
         },
         cmdclass={'install': _PostInstall, 'develop': _PostDevelop},

--- a/setup.py
+++ b/setup.py
@@ -3,26 +3,40 @@ from setuptools.command.install import install
 from setuptools.command.develop import develop
 import os
 import subprocess
+import sys
+import shutil
 
 _REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
 def _install_desktop_file():
-    icon_path = os.path.join(_REPO_ROOT, 'icons', 'pystxmcontrol_icon.png')
-    desktop_dir = os.path.expanduser('~/.local/share/applications')
-    os.makedirs(desktop_dir, exist_ok=True)
-    desktop_path = os.path.join(desktop_dir, 'pystxmcontrol.desktop')
-    with open(desktop_path, 'w') as f:
-        f.write(
-            '[Desktop Entry]\n'
-            'Name=pystxmControl\n'
-            'Exec=python -m pystxmcontrol.gui.main\n'
-            f'Icon={icon_path}\n'
-            'Type=Application\n'
-            'Categories=Science;\n'
-        )
-    subprocess.run(['update-desktop-database', desktop_dir], check=False)
-    print(f'Installed desktop file: {desktop_path}')
+    # Optional Linux desktop integration. Skip on non-Linux platforms (the
+    # freedesktop .desktop file and `update-desktop-database` are Linux-only),
+    # skip when the tool is absent, and never let it fail the build/install —
+    # it is a packaging convenience, not a runtime requirement. Running it
+    # unconditionally raised FileNotFoundError ([WinError 2]) during the wheel
+    # build on Windows, which aborted `pip install`.
+    if not sys.platform.startswith('linux'):
+        return
+    try:
+        icon_path = os.path.join(_REPO_ROOT, 'icons', 'pystxmcontrol_icon.png')
+        desktop_dir = os.path.expanduser('~/.local/share/applications')
+        os.makedirs(desktop_dir, exist_ok=True)
+        desktop_path = os.path.join(desktop_dir, 'pystxmcontrol.desktop')
+        with open(desktop_path, 'w') as f:
+            f.write(
+                '[Desktop Entry]\n'
+                'Name=pystxmControl\n'
+                'Exec=python -m pystxmcontrol.gui.main\n'
+                f'Icon={icon_path}\n'
+                'Type=Application\n'
+                'Categories=Science;\n'
+            )
+        if shutil.which('update-desktop-database'):
+            subprocess.run(['update-desktop-database', desktop_dir], check=False)
+        print(f'Installed desktop file: {desktop_path}')
+    except Exception as exc:  # never block install on desktop integration
+        print(f'Skipped desktop file install: {exc}')
 
 
 class _PostInstall(install):

--- a/tests/remote/conftest.py
+++ b/tests/remote/conftest.py
@@ -50,8 +50,12 @@ from types import SimpleNamespace
 
 _HERE = Path(__file__).resolve().parent
 _DATA_DIR = _HERE / "data"
-_DEFAULT_IOCS_SRC = Path(
-    r"C:\Users\rp\PycharmProjects\ncs\lightfall-pystxmcontrol\_pystxmcontrol_iocs_wt")
+# This worktree lives at <plugin-repo>/_pystxmcontrol_remote_wt and the iocs
+# worktree at <plugin-repo>/_pystxmcontrol_iocs_wt: conftest.py -> parents[0]
+# = tests/remote, [1] = tests, [2] = worktree root, so .parents[2].parent is
+# the plugin repo root. PYSTXMCONTROL_IOCS_SRC env var overrides.
+_DEFAULT_IOCS_SRC = (
+    Path(__file__).resolve().parents[2].parent / "_pystxmcontrol_iocs_wt")
 
 
 @pytest.fixture(scope="session")

--- a/tests/remote/conftest.py
+++ b/tests/remote/conftest.py
@@ -1,6 +1,8 @@
 """Stub NATS for unit-testing LightfallClient without a broker."""
 import json
 
+import pytest
+
 
 class _StubMsg:
     def __init__(self, data: bytes):
@@ -34,3 +36,146 @@ async def stub_connect_factory(stub):
     async def _connect(url):
         return stub
     return _connect
+
+
+# ---- EPICS fleet fixture (ported from spec #3, lightfall-pystxmcontrol) ---
+import os
+import random
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+_HERE = Path(__file__).resolve().parent
+_DATA_DIR = _HERE / "data"
+_DEFAULT_IOCS_SRC = Path(
+    r"C:\Users\rp\PycharmProjects\ncs\lightfall-pystxmcontrol\_pystxmcontrol_iocs_wt")
+
+
+@pytest.fixture(scope="session")
+def iocs_src() -> Path:
+    src = Path(os.environ.get("PYSTXMCONTROL_IOCS_SRC", _DEFAULT_IOCS_SRC))
+    if not (src / "pystxmcontrol" / "iocs" / "supervisor.py").exists():
+        pytest.fail(
+            f"spec-#2 IOC layer not found at {src}. Set PYSTXMCONTROL_IOCS_SRC "
+            "to the pystxmcontrol fork checkout (branch feature/caproto-iocs).")
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    # This worktree's own "pystxmcontrol" package (remote/*) is also on
+    # sys.path (installed editable / PYTHONPATH=cwd for the test run) and,
+    # being a regular (non-namespace) package, wins the first import and
+    # shadows the iocs_src copy entirely -- `import pystxmcontrol.iocs` would
+    # otherwise fail with ModuleNotFoundError even though iocs_src is on
+    # sys.path. Extend the already-imported package's __path__ so submodule
+    # lookups (pystxmcontrol.iocs, pystxmcontrol.drivers, ...) also search
+    # iocs_src's copy.
+    import pystxmcontrol as _pystxmcontrol
+    iocs_pkg_dir = str(src / "pystxmcontrol")
+    if iocs_pkg_dir not in _pystxmcontrol.__path__:
+        _pystxmcontrol.__path__.append(iocs_pkg_dir)
+    return src
+
+
+_issued_udp_ports: set[int] = set()
+
+
+def _free_udp_port() -> int:
+    """Find a UDP port free at bind-time and not already handed out this session.
+
+    Binding and releasing only proves the port was free at that instant; a
+    later call in the same fleet spawn loop could re-discover the same port
+    before the first IOC has claimed it (TOCTOU). Track issued ports across
+    calls so sequential spawns never collide with each other.
+    """
+    for _ in range(50):
+        port = random.randint(40000, 60000)
+        if port in _issued_udp_ports:
+            continue
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                _issued_udp_ports.add(port)
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("no free UDP port found")
+
+
+@pytest.fixture(scope="session")
+def stxm_fleet(iocs_src, tmp_path_factory):
+    """Spawn the full sim IOC fleet (spec-#2 supervisor plan) once per session.
+
+    Uses the sim_motor.json / sim_daq.json copied locally into
+    tests/remote/data/ rather than reaching across into the
+    lightfall_pystxmcontrol plugin package (this repo is a separate
+    checkout/worktree of pystxmcontrol itself).
+    """
+    import netifaces  # noqa: F401  (required optional caproto dep; fail fast)
+    os.environ.setdefault("OPHYD_CONTROL_LAYER", "caproto")
+    from pystxmcontrol.iocs.config import load_fleet
+    from pystxmcontrol.iocs.supervisor import plan_fleet
+
+    slice_dir = tmp_path_factory.mktemp("stxm_slices")
+    fleet = load_fleet(str(_DATA_DIR / "sim_motor.json"),
+                        str(_DATA_DIR / "sim_daq.json"), station="SIM")
+
+    _DAQ_KEY = "default"  # sim_daq.json key; matches lightfall_pystxmcontrol.flyer
+    assert fleet.daqs[0].key == _DAQ_KEY, (
+        f"fleet daq key {fleet.daqs[0].key!r} != expected {_DAQ_KEY!r}; "
+        "sim_daq.json was likely renamed/restructured (fails fast here "
+        "instead of hanging on a PV connect below)")
+
+    plans = plan_fleet(fleet, str(slice_dir))
+
+    addr_entries: list[str] = []
+    procs: list[subprocess.Popen] = []
+    for plan in plans:
+        port = _free_udp_port()
+        addr_entries.append(f"127.0.0.1:{port}")
+        env = dict(os.environ)
+        env.update({
+            "EPICS_CAS_SERVER_PORT": str(port),
+            "EPICS_CA_SERVER_PORT": str(port),   # caproto server binds via this
+            "EPICS_CA_ADDR_LIST": " ".join(addr_entries),
+            "EPICS_CA_AUTO_ADDR_LIST": "NO",
+            "PYTHONPATH": str(iocs_src),
+        })
+        procs.append(subprocess.Popen(
+            [sys.executable, "-m", plan.module, "--slice", plan.slice_path,
+             "--quiet"],
+            env=env, cwd=str(iocs_src)))
+        time.sleep(0.5)
+
+    addr_list = " ".join(addr_entries)
+    saved_env = {k: os.environ.get(k)
+                 for k in ("EPICS_CA_ADDR_LIST", "EPICS_CA_AUTO_ADDR_LIST")}
+    os.environ["EPICS_CA_ADDR_LIST"] = addr_list
+    os.environ["EPICS_CA_AUTO_ADDR_LIST"] = "NO"
+    try:
+        time.sleep(3.0)
+        dead = [p.args for p in procs if p.poll() is not None]
+        assert not dead, f"IOC(s) exited early: {dead}"
+
+        e712_label = next(g.label for g in fleet.controller_groups
+                          if g.controller_cls == "E712Controller")
+        yield SimpleNamespace(
+            addr_list=addr_list,
+            motor_pv=fleet.motor_pv,
+            fly_prefix=f"STXMSIM:{e712_label}:FLY",
+            daq_prefix=fleet.daqs[0].prefix,
+        )
+    finally:
+        for p in procs:
+            if p.poll() is None:
+                p.terminate()
+                try:
+                    p.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    p.kill()
+        for key, prior in saved_env.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior

--- a/tests/remote/conftest.py
+++ b/tests/remote/conftest.py
@@ -1,0 +1,36 @@
+"""Stub NATS for unit-testing LightfallClient without a broker."""
+import json
+
+
+class _StubMsg:
+    def __init__(self, data: bytes):
+        self.data = data
+
+
+class StubNats:
+    """Duck-types the nats-py client surface LightfallClient uses."""
+
+    def __init__(self):
+        self.handlers = {}       # exact subject -> callable(payload dict) -> dict
+        self.subscriptions = {}  # subject -> cb
+        self.requests = []       # (subject, payload) log
+
+    async def request(self, subject, data, timeout=None):
+        payload = json.loads(data.decode())
+        self.requests.append((subject, payload))
+        for pat, handler in self.handlers.items():
+            if subject == pat or (pat.endswith(".*") and subject.startswith(pat[:-1])):
+                return _StubMsg(json.dumps(handler(subject, payload)).encode())
+        raise TimeoutError(f"no stub handler for {subject}")
+
+    async def subscribe(self, subject, cb=None):
+        self.subscriptions[subject] = cb
+
+    async def drain(self):
+        pass
+
+
+async def stub_connect_factory(stub):
+    async def _connect(url):
+        return stub
+    return _connect

--- a/tests/remote/conftest.py
+++ b/tests/remote/conftest.py
@@ -183,3 +183,313 @@ def stxm_fleet(iocs_src, tmp_path_factory):
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = prior
+
+
+# ---- Real Lightfall RemoteControlService fixture (Task 8) -----------------
+#
+# Wires a REAL lightfall.remote.service.RemoteControlService (real NATS via
+# lightfall.ipc.local_server.LocalNatsServer, real BlueskyEngine, real
+# TrustManager pre-approved), backed by:
+#   - the sim IOC fleet (stxm_fleet) via real ophyd EpicsMotor devices for
+#     SampleX/SampleY/energy and a real StxmLineFlyer for the FLY PVGroup;
+#   - a duck-typed catalog (mirrors lightfall's own
+#     tests/integration/test_remote_control_e2e.py::_Catalog pattern rather
+#     than booting a full lightfall Application/PluginManager/GUI, which
+#     would be disproportionate for exercising the remote contract);
+#   - the stxm_fly_raster plan, bound directly to the real flyer/y-axis and
+#     registered into lightfall's process-wide PlanRegistry singleton;
+#   - a real (uvicorn, real TCP port) Tiled server via
+#     tiled.server.SimpleTiledServer, with a TiledWriter subscribed to the
+#     real RunEngine so runs actually land and are independently readable.
+#
+# Session-scoped and depends on stxm_fleet so EPICS_CA_ADDR_LIST/the fleet
+# IOCs are up before any EpicsMotor/StxmLineFlyer tries to connect.
+
+import inspect as _inspect
+from types import SimpleNamespace as _SimpleNamespace
+from urllib.parse import urlparse as _urlparse
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _assert_lightfall_has_pv_field() -> None:
+    """Fail fast (not skip) if lightfall isn't on feature/device-info-pv.
+
+    device.info replies must carry a ``pv`` field (spec #4 Task 1); rather
+    than shelling out to git (this checkout may be a worktree/site-packages
+    install with no .git at all), check the actual behavior we depend on:
+    RemoteControlService._handle_device_info must emit ``pv=...`` in its
+    reply. If it doesn't, every test here would fail confusingly deep inside
+    the contract assertions instead of with an actionable message.
+    """
+    from lightfall.remote import service as _lf_service_mod
+
+    src = _inspect.getsource(_lf_service_mod)
+    if "pv=" not in src or "getattr(info, \"prefix\"" not in src.replace("'", '"'):
+        pytest.fail(
+            "lightfall's RemoteControlService.device.info reply has no 'pv' "
+            "field. Check out branch 'feature/device-info-pv' (or its "
+            "merge target) in the lightfall checkout used by this venv "
+            "before running tests/remote/test_contract.py / "
+            "test_e2e_gui.py."
+        )
+
+
+@pytest.fixture(scope="session")
+def lightfall_nats_url():
+    from lightfall.ipc.local_server import LocalNatsServer, resolve_nats_binary
+
+    if resolve_nats_binary() is None:
+        pytest.skip("nats-server binary not available (install extra local-nats)")
+    port = _free_port()
+    server = LocalNatsServer(port=port)
+    server.start(timeout_s=10.0)
+    yield f"nats://127.0.0.1:{port}"
+    server.stop()
+
+
+@pytest.fixture(scope="session")
+def qapp_session():
+    """One process-wide Qt application for the session-scoped service fixture
+    to pump events on while waiting for NATS/engine warm-up."""
+    from PySide6.QtCore import QCoreApplication
+    from PySide6 import QtWidgets
+
+    app = QCoreApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication([])
+    return app
+
+
+def _pump_qt_until_session(qapp, predicate, timeout=30.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.fixture(scope="session")
+def lightfall_service(stxm_fleet, lightfall_nats_url, qapp_session):
+    """Real RemoteControlService + real fleet devices/plan + real Tiled.
+
+    Yields a SimpleNamespace with: ipc, trust, engine, remote, prefix,
+    catalog, motor_pv (name -> pv), tiled_url, tiled_token, tiled_client
+    (a from_uri client independent of any LightfallClient, for cross-checks).
+    """
+    _assert_lightfall_has_pv_field()
+
+    from lightfall.acquire.engine import get_engine, reset_engine
+    from lightfall.acquire.plans.registry import get_registry
+    from lightfall.devices.model import DeviceCategory, DeviceInfo
+    from lightfall.ipc.service import IPCService
+    from lightfall.ipc.trust import TrustManager, TrustState
+    from lightfall.remote.service import RemoteControlService
+    from lightfall.utils.threads import initialize_main_thread_invoker
+
+    try:
+        initialize_main_thread_invoker()
+    except RuntimeError:
+        pass  # already initialized by an earlier test/fixture in this process
+
+    # Import AFTER stxm_fleet has set OPHYD_CONTROL_LAYER=caproto: these
+    # modules build ophyd EpicsSignal-backed objects whose control layer is
+    # selected at ophyd import time, so importing them before the fleet
+    # fixture ran would silently pick the wrong (pyepics) control layer.
+    from ophyd import EpicsMotor
+
+    from lightfall_pystxmcontrol.flyer import StxmLineFlyer
+    from lightfall_pystxmcontrol.plans import stxm_fly_raster
+
+    motor_pv = dict(stxm_fleet.motor_pv)
+    motor_x = EpicsMotor(motor_pv["SampleX"], name="SampleX")
+    motor_y = EpicsMotor(motor_pv["SampleY"], name="SampleY")
+    motor_e = EpicsMotor(motor_pv["energy"], name="energy")
+    flyer = StxmLineFlyer(stxm_fleet.fly_prefix, name="STXMLineFlyer")
+    for dev in (motor_x, motor_y, motor_e, flyer):
+        dev.wait_for_connection(timeout=20)
+
+    devices = {
+        "SampleX": (
+            DeviceInfo(name="SampleX", category=DeviceCategory.MOTOR,
+                       device_class="ophyd.EpicsMotor", prefix=motor_pv["SampleX"]),
+            motor_x,
+        ),
+        "SampleY": (
+            DeviceInfo(name="SampleY", category=DeviceCategory.MOTOR,
+                       device_class="ophyd.EpicsMotor", prefix=motor_pv["SampleY"]),
+            motor_y,
+        ),
+        "energy": (
+            DeviceInfo(name="energy", category=DeviceCategory.MOTOR,
+                       device_class="ophyd.EpicsMotor", prefix=motor_pv["energy"]),
+            motor_e,
+        ),
+    }
+
+    class _Catalog:
+        def list_devices(self, **kw):
+            return [info for info, _ in devices.values()]
+
+        def get_device_by_name(self, name):
+            pair = devices.get(name)
+            return pair[0] if pair else None
+
+        def get_ophyd_device(self, name):
+            pair = devices.get(name)
+            return pair[1] if pair else None
+
+    catalog = _Catalog()
+
+    # Bind + register the real stxm_fly_raster plan (params exactly matching
+    # scan_mapping.map_scan's stxm_fly_raster output: y_start/y_stop/ny/
+    # x_start/x_stop/nx/dwell) against the real flyer + Y axis.
+    def _stxm_fly_raster_bound(*, y_start, y_stop, ny, x_start, x_stop, nx, dwell):
+        return (yield from stxm_fly_raster(
+            flyer, motor_y, y_start=y_start, y_stop=y_stop, ny=ny,
+            x_start=x_start, x_stop=x_stop, nx=nx, dwell=dwell))
+
+    registry = get_registry()
+    if "stxm_fly_raster" not in registry:
+        registry.register("stxm_fly_raster", _stxm_fly_raster_bound, category="stxm")
+
+    reset_engine()
+    engine = get_engine("bluesky")
+
+    prefix = "als.stxmtest"
+    ipc = IPCService(nats_url=lightfall_nats_url, topic_prefix=prefix)
+    trust = TrustManager()
+    trust.approve("stxm-remote-test")
+    ipc.set_trust_manager(trust)
+    ipc.register_meta_endpoints()
+
+    # Real (uvicorn, real TCP port) Tiled server -- LightfallClient.tiled_client()
+    # makes real HTTP calls via tiled.client.from_uri, so an ASGI-only
+    # Context.from_app() client (as lightfall's own test_run_lands_in_tiled
+    # uses) is not sufficient here.
+    #
+    # NOT using tiled.server.SimpleTiledServer: it hardcodes a duckdb:///
+    # SQLStorage backend for the "internal" (non-array event data) table,
+    # and this venv's Python (3.14) has no adbc_driver_duckdb wheel
+    # available -- every create_appendable_table() call for ANY run with
+    # real event data (not just start/stop docs) 500s server-side on the
+    # missing import, and the client's retry_context() then re-POSTs the
+    # same (non-idempotent) create, which 409s because the metadata record
+    # from the first, failed attempt already exists. Reproduced in
+    # isolation with a bare RunEngine + ophyd.sim signals + TiledWriter --
+    # nothing to do with pystxmcontrol/lightfall code. Root-caused via:
+    # sqlite:/// storage instead of duckdb:/// (adbc_driver_sqlite IS
+    # available for this Python) avoids the missing-driver 500/409 entirely.
+    # sqlite's SQL dialect additionally has no list/array column type, so
+    # array-shaped data_keys (X positions, detector counts) must clear
+    # bluesky_tiled_plugins.writing.tiled_writer.MAX_ARRAY_SIZE (16
+    # elements) to be routed to the zarr array-write path instead of an
+    # embedded list column in the "internal" table -- callers must use
+    # nx (or any array-shaped column length) > 16 in any plan run against
+    # this fixture.
+    import pathlib
+    import tempfile
+    import threading
+
+    import uvicorn
+    from tiled.catalog import in_memory as tiled_in_memory
+    from tiled.config import Authentication
+    from tiled.server.app import build_app
+
+    tiled_api_key = "stxmremotetestkey123"  # must be alphanumeric-only (tiled requirement)
+    tiled_dir = pathlib.Path(tempfile.mkdtemp(prefix="stxm_remote_test_tiled_"))
+    (tiled_dir / "data").mkdir(parents=True, exist_ok=True)
+    tiled_storage_uri = f"sqlite:///{tiled_dir / 'storage.sqlite'}"
+    tiled_catalog = tiled_in_memory(
+        writable_storage=[tiled_dir / "data", tiled_storage_uri])
+    tiled_app = build_app(
+        tiled_catalog,
+        authentication=Authentication(single_user_api_key=tiled_api_key))
+
+    class _ThreadedTiledServer(uvicorn.Server):
+        def install_signal_handlers(self) -> None:
+            pass  # not the main thread; would raise
+
+    tiled_uvicorn_config = uvicorn.Config(
+        tiled_app, host="127.0.0.1", port=0, loop="asyncio")
+    tiled_uvicorn_server = _ThreadedTiledServer(config=tiled_uvicorn_config)
+    tiled_thread = threading.Thread(target=tiled_uvicorn_server.run, daemon=True)
+    tiled_thread.start()
+    for _ in range(200):
+        time.sleep(0.1)
+        if tiled_uvicorn_server.started:
+            break
+    else:
+        pytest.fail("Tiled server did not start in 20 seconds.")
+    _tiled_host, _tiled_port = (
+        tiled_uvicorn_server.servers[0].sockets[0].getsockname())
+    tiled_url = f"http://{_tiled_host}:{_tiled_port}"
+
+    def handle_auth(subject, data, reply):
+        app_name = data.get("app_name", "unknown")
+        if ipc.evaluate_trust(app_name) == TrustState.APPROVED:
+            resp = {
+                "status": "approved",
+                "contract_version": 1,
+                "tiled_url": tiled_url,
+                "tiled_token": tiled_api_key,
+            }
+            resp["session_token"] = ipc.mint_session_channel(app_name)
+            ipc.reply(reply, resp)
+        else:
+            ipc.reply(reply, {"status": "denied", "contract_version": 1})
+
+    ipc.register_action("auth.request", handle_auth, main_thread=False)
+
+    remote = RemoteControlService(ipc, engine=engine, catalog=catalog)
+    remote.start()
+    ipc.start()
+
+    assert _pump_qt_until_session(qapp_session, lambda: ipc.is_connected, timeout=15), \
+        "IPCService never connected to the local NATS server"
+
+    # Wait for the BlueskyEngine's RunEngine to boot on its worker thread,
+    # then attach a TiledWriter so runs actually land (mirrors lightfall's
+    # own test_run_lands_in_tiled wiring, but against a real Tiled server).
+    assert _pump_qt_until_session(qapp_session, lambda: engine.RE is not None, timeout=30), \
+        "BlueskyEngine.RE never booted"
+    assert _pump_qt_until_session(qapp_session, lambda: engine.is_idle, timeout=30), \
+        "engine never reached idle after boot"
+
+    from bluesky_tiled_plugins import TiledWriter
+    from tiled.client import from_uri
+
+    tiled_client = from_uri(tiled_url, api_key=tiled_api_key)
+    writer_token = engine.RE.subscribe(TiledWriter(tiled_client))
+
+    yield _SimpleNamespace(
+        ipc=ipc, trust=trust, engine=engine, remote=remote, prefix=prefix,
+        catalog=catalog, motor_pv=motor_pv, tiled_url=tiled_url,
+        tiled_token=tiled_api_key, tiled_client=tiled_client,
+        motor_x=motor_x, motor_y=motor_y, motor_e=motor_e, flyer=flyer,
+        qapp=qapp_session,
+    )
+
+    try:
+        engine.RE.unsubscribe(writer_token)
+    except Exception:
+        pass
+    remote.stop()
+    ipc.stop()
+    reset_engine()
+    for dev in (motor_x, motor_y, motor_e, flyer):
+        try:
+            dev.destroy()
+        except Exception:
+            pass
+    try:
+        tiled_uvicorn_server.should_exit = True
+        tiled_thread.join(timeout=10)
+    except Exception:
+        pass

--- a/tests/remote/data/sim_daq.json
+++ b/tests/remote/data/sim_daq.json
@@ -1,0 +1,8 @@
+{
+    "default": {
+        "index": 0, "name": "Counter1", "type": "point", "driver": "keysight53230A",
+        "address": "sim", "trigger_mode": "line", "measurement_mode": "TOT",
+        "port": 5025, "channel": 1, "oversampling_factor": 1, "ndim": 0,
+        "gate": false, "record": true, "simulation": true
+    }
+}

--- a/tests/remote/data/sim_motor.json
+++ b/tests/remote/data/sim_motor.json
@@ -1,0 +1,20 @@
+{
+    "SampleX": {
+        "index": 0, "type": "primary", "axis": "x", "driver": "E712Motor",
+        "controllerID": "192.168.1.201", "port": 5000, "controller": "E712Controller",
+        "max velocity": 1000.0, "minValue": -100.0, "maxValue": 100.0,
+        "offset": 0.0, "units": 1.0, "display": true, "simulation": 1
+    },
+    "SampleY": {
+        "index": 1, "type": "primary", "axis": "y", "driver": "E712Motor",
+        "controllerID": "192.168.1.201", "port": 5000, "controller": "E712Controller",
+        "max velocity": 1000.0, "minValue": -100.0, "maxValue": 100.0,
+        "offset": 0.0, "units": 1.0, "display": true, "simulation": 1
+    },
+    "energy": {
+        "index": 2, "type": "primary", "axis": "x", "driver": "xpsMotor",
+        "controllerID": "192.168.1.254", "port": 0, "controller": "xpsController",
+        "max velocity": 1000.0, "minValue": 250.0, "maxValue": 2500.0,
+        "offset": 0.0, "units": 1.0, "display": true, "simulation": 1
+    }
+}

--- a/tests/remote/fakes.py
+++ b/tests/remote/fakes.py
@@ -1,0 +1,112 @@
+"""Shared test doubles for the remote-GUI Qt test suite (spec #4 Tasks 5+7).
+
+Moved out of test_qt_bridge.py so test_qt_integration.py (Task 7) can reuse
+the same FakeLightfallClient / FakeMonitorSet without duplicating them.
+"""
+from __future__ import annotations
+
+import time
+
+
+class FakeLightfallClient:
+    """Duck-types the async surface RemoteBackend consumes; canned replies."""
+
+    def __init__(self):
+        self.session_token = None
+        self.tiled_url = None
+        self.tiled_token = None
+        self.call_log: list[tuple[str, dict]] = []
+        self.subscriptions: dict[str, callable] = {}
+        self.call_handlers: dict[str, callable] = {}
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def authenticate(self, timeout: float = 90.0) -> dict:
+        self.session_token = "tok123"
+        self.tiled_url = "http://tiled"
+        self.tiled_token = "tt"
+        return {"status": "approved", "session_token": "tok123"}
+
+    async def call(self, suffix: str, payload: dict | None = None, timeout: float = 5.0) -> dict:
+        payload = dict(payload or {})
+        self.call_log.append((suffix, payload))
+        handler = self.call_handlers.get(suffix)
+        if handler is not None:
+            return handler(payload)
+        return {"status": "ok"}
+
+    async def subscribe_event(self, suffix: str, callback) -> None:
+        self.subscriptions[suffix] = callback
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def tiled_client(self):
+        raise AssertionError("tiled_client() not stubbed for this test")
+
+    # test helper: fire a broadcast event as if received off the wire
+    def fire(self, suffix: str, payload: dict) -> None:
+        cb = self.subscriptions[suffix]
+        cb(payload)
+
+
+class FakeMonitorSet:
+    """Stand-in for MotorMonitorSet -- injected via monitor_factory."""
+
+    instances: list["FakeMonitorSet"] = []
+
+    def __init__(self, motors, on_update, min_period_s: float = 0.2):
+        self.motors = motors
+        self.on_update = on_update
+        self.started = False
+        self.stopped = False
+        FakeMonitorSet.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+class FakeRunStreamer:
+    """Stand-in for RunStreamer -- captures the on_image/on_progress/on_error
+    callbacks so a test can fire a synthesized image without any real Tiled
+    connection or background thread."""
+
+    instances: list["FakeRunStreamer"] = []
+
+    def __init__(self, tiled_client_factory, run_uid, on_image, on_progress,
+                 *, on_error=None, poll_s: float = 1.0, data_field: str = "Counter1"):
+        self.tiled_client_factory = tiled_client_factory
+        self.run_uid = run_uid
+        self.on_image = on_image
+        self.on_progress = on_progress
+        self.on_error = on_error
+        self.started = False
+        self.stopped = False
+        FakeRunStreamer.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+    # test helper: synthesize a poll result directly (no thread, no Tiled)
+    def fire_image(self, image_dict: dict, extents=((0, 1), (0, 1))) -> None:
+        self.on_image(image_dict, extents)
+
+
+def wait_for(qapp, predicate, timeout_s: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.01)
+    qapp.processEvents()
+    return predicate()

--- a/tests/remote/test_ca_monitors.py
+++ b/tests/remote/test_ca_monitors.py
@@ -1,0 +1,187 @@
+"""MotorMonitorSet against the live sim fleet (spec #4 Task 4)."""
+import statistics
+import threading
+import time
+
+import pytest
+
+from pystxmcontrol.remote.ca_monitors import MotorMonitorSet
+
+
+class _Collector:
+    """Thread-safe callback collector for on_update payloads."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.calls: list[dict] = []
+
+    def __call__(self, payload: dict) -> None:
+        with self._lock:
+            self.calls.append(payload)
+
+    def snapshot(self) -> list[dict]:
+        with self._lock:
+            return list(self.calls)
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.02):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+@pytest.fixture
+def two_motors(stxm_fleet):
+    return {
+        "SampleX": stxm_fleet.motor_pv["SampleX"],
+        "SampleY": stxm_fleet.motor_pv["SampleY"],
+    }
+
+
+def test_initial_snapshot_within_5s(two_motors):
+    collector = _Collector()
+    mon = MotorMonitorSet(two_motors, collector, min_period_s=0.2)
+    mon.start()
+    try:
+        ok = _wait_until(
+            lambda: any(
+                "SampleX" in c and "SampleY" in c for c in collector.snapshot()
+            )
+            or (
+                any("SampleX" in c for c in collector.snapshot())
+                and any("SampleY" in c for c in collector.snapshot())
+            ),
+            timeout=5.0,
+        )
+        assert ok, f"no initial snapshot within 5s: {collector.snapshot()}"
+        names_seen = {k for c in collector.snapshot() for k in c if k != "status"}
+        assert {"SampleX", "SampleY"} <= names_seen
+    finally:
+        mon.stop()
+
+
+def test_move_reports_position_and_status_transition(two_motors):
+    from caproto.threading.client import Context
+
+    collector = _Collector()
+    mon = MotorMonitorSet(two_motors, collector, min_period_s=0.1)
+    mon.start()
+    client_ctx = None
+    try:
+        assert _wait_until(lambda: mon.connected.get("SampleX") is True)
+
+        client_ctx = Context()
+        (val_pv,) = client_ctx.get_pvs(f"{two_motors['SampleX']}.VAL")
+        val_pv.wait_for_connection(timeout=10)
+        val_pv.write([7.0], wait=False)
+
+        def _arrived():
+            calls = collector.snapshot()
+            return any(
+                "SampleX" in c and abs(c["SampleX"] - 7.0) < 1e-3 for c in calls
+            )
+
+        assert _wait_until(_arrived, timeout=10.0), (
+            f"SampleX never reported ~7.0: {collector.snapshot()}"
+        )
+
+        # Collect the status sequence for SampleX across all callbacks.
+        status_seq = [
+            c["status"]["SampleX"]
+            for c in collector.snapshot()
+            if "status" in c and "SampleX" in c["status"]
+        ]
+        assert status_seq, "no status updates observed for SampleX"
+        # The E712 sim move is effectively instantaneous, so True->False may
+        # collapse into a single coalesced flush that only reports the final
+        # False; assert on the final resting state (False) plus, if a
+        # transition was actually observable, that it went True before False.
+        assert status_seq[-1] is False
+        if True in status_seq:
+            assert status_seq.index(True) < len(status_seq) - list(
+                reversed(status_seq)
+            ).index(False)
+    finally:
+        mon.stop()
+        if client_ctx is not None:
+            client_ctx.disconnect()
+
+
+def test_rate_limiting_inter_arrival_timestamps(stxm_fleet):
+    from caproto.threading.client import Context
+
+    motors = {"energy": stxm_fleet.motor_pv["energy"]}
+    timestamps: list[float] = []
+    lock = threading.Lock()
+
+    def _on_update(_payload):
+        with lock:
+            timestamps.append(time.monotonic())
+
+    min_period = 0.3
+    mon = MotorMonitorSet(motors, _on_update, min_period_s=min_period)
+    mon.start()
+    client_ctx = None
+    try:
+        assert _wait_until(lambda: mon.connected.get("energy") is True)
+
+        client_ctx = Context()
+        (val_pv,) = client_ctx.get_pvs(f"{motors['energy']}.VAL")
+        val_pv.wait_for_connection(timeout=10)
+
+        for target in range(600, 630):
+            val_pv.write([float(target)], wait=True, timeout=10)
+
+        assert _wait_until(lambda: len(timestamps) >= 6, timeout=20.0)
+    finally:
+        mon.stop()
+        if client_ctx is not None:
+            client_ctx.disconnect()
+
+    with lock:
+        ts = list(timestamps)
+    diffs = [b - a for a, b in zip(ts, ts[1:])]
+    assert diffs, "not enough callbacks to measure inter-arrival"
+    median = statistics.median(diffs)
+    assert median >= 0.8 * min_period, (
+        f"median inter-arrival {median} < 0.8*{min_period}: diffs={diffs}"
+    )
+
+
+def test_stop_silences_callbacks(two_motors):
+    collector = _Collector()
+    mon = MotorMonitorSet(two_motors, collector, min_period_s=0.1)
+    mon.start()
+    try:
+        assert _wait_until(lambda: len(collector.snapshot()) > 0)
+    finally:
+        mon.stop()
+
+    count_after_stop = len(collector.snapshot())
+    time.sleep(1.0)
+    assert len(collector.snapshot()) == count_after_stop, (
+        "callbacks continued to arrive after stop()"
+    )
+
+
+def test_unknown_pv_reports_disconnected(stxm_fleet):
+    motors = {
+        "SampleX": stxm_fleet.motor_pv["SampleX"],
+        "Bogus": "STXMSIM:DOES:NOT:EXIST",
+    }
+    collector = _Collector()
+    mon = MotorMonitorSet(motors, collector, min_period_s=0.2)
+    mon.start()
+    try:
+        assert _wait_until(lambda: mon.connected.get("SampleX") is True)
+        # Bogus never connects; give it the same generous window before
+        # asserting it stays disconnected without disturbing SampleX.
+        time.sleep(2.0)
+        connected = mon.connected
+        assert connected["Bogus"] is False
+        assert connected["SampleX"] is True
+    finally:
+        mon.stop()

--- a/tests/remote/test_client.py
+++ b/tests/remote/test_client.py
@@ -1,0 +1,64 @@
+import json
+
+import pytest
+
+from pystxmcontrol.remote.client import CONTRACT_VERSION, LightfallClient, RemoteError
+from .conftest import StubNats
+
+
+@pytest.fixture
+def stub():
+    return StubNats()
+
+
+@pytest.fixture
+async def client(stub):
+    async def _connect(url):
+        return stub
+    c = LightfallClient("nats://x", "als.test", "stxm-gui", _nats_connect=_connect)
+    await c.connect()
+    return c
+
+
+async def test_authenticate_stores_token_and_tiled(client, stub):
+    stub.handlers["als.test.auth.request"] = lambda s, p: {
+        "status": "approved", "session_token": "tok123",
+        "tiled_url": "http://t", "tiled_token": "tt"}
+    reply = await client.authenticate()
+    assert reply["status"] == "approved"
+    assert client.session_token == "tok123"
+    assert client.tiled_url == "http://t"
+
+
+async def test_call_travels_on_capability_channel(client, stub):
+    stub.handlers["als.test.auth.request"] = lambda s, p: {
+        "status": "approved", "session_token": "tok123"}
+    await client.authenticate()
+    stub.handlers["als.test.session.tok123.commands.engine.status"] = (
+        lambda s, p: {"status": "ok", "state": "idle", "contract_version": 1})
+    reply = await client.call("commands.engine.status")
+    assert reply["state"] == "idle"
+    subject, payload = stub.requests[-1]
+    assert subject == "als.test.session.tok123.commands.engine.status"
+    assert payload["contract_version"] == CONTRACT_VERSION
+
+
+async def test_structured_error_raises(client, stub):
+    stub.handlers["als.test.auth.request"] = lambda s, p: {
+        "status": "approved", "session_token": "tok123"}
+    await client.authenticate()
+    stub.handlers["als.test.session.tok123.commands.plan.run"] = (
+        lambda s, p: {"status": "error", "code": "busy", "message": "engine busy"})
+    with pytest.raises(RemoteError) as ei:
+        await client.call("commands.plan.run", {"plan_name": "x"})
+    assert ei.value.code == "busy"
+
+
+async def test_call_before_auth_raises(client):
+    with pytest.raises(RuntimeError):
+        await client.call("commands.engine.status")
+
+
+async def test_tiled_client_requires_auth(client):
+    with pytest.raises(RuntimeError):
+        client.tiled_client()

--- a/tests/remote/test_contract.py
+++ b/tests/remote/test_contract.py
@@ -1,0 +1,205 @@
+"""Live contract tests: the REAL LightfallClient against a REAL
+RemoteControlService + real NATS + real sim IOC fleet + real Tiled
+(spec #4 Task 8).
+
+Uses the ``lightfall_service`` fixture (tests/remote/conftest.py), which
+wires the real fleet devices (SampleX/SampleY/energy EpicsMotors + the
+StxmLineFlyer) and the real ``stxm_fly_raster`` plan into a real
+RemoteControlService. No fakes/stubs anywhere in this module.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from pystxmcontrol.remote.client import LightfallClient, RemoteError
+
+
+class _ClientRunner:
+    """Drives the async LightfallClient from sync test code on a thread,
+    pumping the session's Qt event loop while waiting (mirrors lightfall's
+    own tests/integration/test_remote_control_e2e.py::_ClientRunner --
+    engine document signals cross threads via Qt, so a plain blocking
+    future.result(timeout) would starve that queue for the whole call)."""
+
+    def __init__(self, nats_url, prefix, qapp, app_name="stxm-remote-test"):
+        self.client = LightfallClient(nats_url, prefix, app_name)
+        self.qapp = qapp
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self._thread.start()
+
+    def run(self, coro, timeout=30.0):
+        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
+        deadline = time.monotonic() + timeout
+        while not future.done():
+            self.qapp.processEvents()
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.05)
+        return future.result(timeout=0.1)
+
+    def close(self):
+        try:
+            self.run(self.client.close(), timeout=5)
+        finally:
+            self.loop.call_soon_threadsafe(self.loop.stop)
+            self._thread.join(timeout=5)
+
+
+def _pump_qt_until(qapp, predicate, timeout=30.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.fixture
+def nats_url(lightfall_service):
+    # LocalNatsServer URL isn't stored on the namespace; reconstruct it from
+    # the IPCService, which was constructed with it.
+    return lightfall_service.ipc._nats_url  # noqa: SLF001 - test-only introspection
+
+
+@pytest.fixture
+def client(lightfall_service, nats_url):
+    runner = _ClientRunner(nats_url, lightfall_service.prefix, lightfall_service.qapp)
+    runner.run(runner.client.connect())
+    yield runner
+    runner.close()
+
+
+def _read_rbv_via_ca(pv: str, timeout: float = 10.0) -> float:
+    """Independent CA read of ``<pv>.RBV`` -- verifies device.put actually
+    moved hardware rather than trusting the reply alone."""
+    from caproto.threading.client import Context
+
+    ctx = Context()
+    try:
+        (rbv_pv,) = ctx.get_pvs(f"{pv}.RBV")
+        rbv_pv.wait_for_connection(timeout=timeout)
+        response = rbv_pv.read(data_type="time")
+        return float(response.data[0])
+    finally:
+        ctx.disconnect()
+
+
+def test_authenticate_returns_token_and_tiled_fields(lightfall_service, client):
+    auth = client.run(client.client.authenticate())
+    assert auth["status"] == "approved"
+    assert auth["contract_version"] == 1
+    assert client.client.session_token
+    assert client.client.tiled_url == lightfall_service.tiled_url
+    assert client.client.tiled_token == lightfall_service.tiled_token
+
+
+def test_bare_subject_call_is_denied(client):
+    reply = client.run(client.client.call_bare("commands.engine.status", {}))
+    assert reply["status"] == "error"
+    assert reply["code"] == "denied"
+
+
+def _device_info_by_name(client, name):
+    return client.run(client.client.call("commands.device.info", {"device": name}))
+
+
+def test_device_search_and_info_expose_pv(lightfall_service, client):
+    client.run(client.client.authenticate())
+
+    search = client.run(client.client.call("commands.device.search", {}))
+    devices = set(search["devices"])
+    assert {"SampleX", "SampleY", "energy"} <= devices
+
+    for name in ("SampleX", "SampleY", "energy"):
+        info = _device_info_by_name(client, name)
+        pv = info.get("pv")
+        assert pv, (
+            f"device.info for {name!r} has no 'pv' field ({info!r}). "
+            "Check out branch 'feature/device-info-pv' in the lightfall "
+            "checkout used by this venv."
+        )
+        assert pv == lightfall_service.motor_pv[name], (
+            f"device.info pv {pv!r} for {name!r} does not match the fleet's "
+            f"actual PV {lightfall_service.motor_pv[name]!r}"
+        )
+
+
+def test_device_put_moves_sample_y_verified_over_ca(lightfall_service, client):
+    client.run(client.client.authenticate())
+    assert _pump_qt_until(lightfall_service.qapp, lambda: lightfall_service.engine.is_idle,
+                           timeout=30), "engine never warmed up"
+
+    target = 3.0
+    reply = client.run(
+        client.client.call("commands.device.put", {"device": "SampleY", "value": target},
+                            timeout=20)
+    )
+    assert reply["status"] == "ok"
+
+    rbv = _read_rbv_via_ca(lightfall_service.motor_pv["SampleY"])
+    assert rbv == pytest.approx(target, abs=0.05)
+    assert lightfall_service.motor_y.position == pytest.approx(target, abs=0.05)
+
+
+def test_plan_list_contains_stxm_fly_raster(client):
+    client.run(client.client.authenticate())
+    plans = client.run(client.client.call("commands.plan.list", {}))["plans"]
+    assert any(p["name"] == "stxm_fly_raster" for p in plans)
+
+
+def test_busy_rejection_while_plan_runs(lightfall_service, client):
+    client.run(client.client.authenticate())
+    assert _pump_qt_until(lightfall_service.qapp, lambda: lightfall_service.engine.is_idle,
+                           timeout=30), "engine never warmed up"
+
+    # A slow-enough raster (small but nonzero dwell, several rows) to observe
+    # the engine mid-flight without dragging the test out.
+    reply = client.run(
+        client.client.call(
+            "commands.plan.run",
+            {
+                "plan_name": "stxm_fly_raster",
+                "params": {
+                    "y_start": -2.0, "y_stop": 2.0, "ny": 20,
+                    "x_start": -2.0, "x_stop": 2.0, "nx": 20,
+                    "dwell": 20.0,
+                },
+            },
+            timeout=20,
+        )
+    )
+    assert reply["status"] == "submitted"
+
+    def _is_running() -> bool:
+        status = client.run(client.client.call("commands.engine.status", {}))
+        return status["state"] == "running"
+
+    assert _pump_qt_until(lightfall_service.qapp, _is_running, timeout=20), \
+        "engine never reported running"
+
+    with pytest.raises(RemoteError) as exc_info:
+        client.run(
+            client.client.call("commands.plan.run",
+                                {"plan_name": "stxm_fly_raster", "params": {}})
+        )
+    assert exc_info.value.code == "busy"
+
+    with pytest.raises(RemoteError) as exc_info:
+        client.run(
+            client.client.call("commands.device.put",
+                                {"device": "SampleY", "value": 0.0})
+        )
+    assert exc_info.value.code == "busy"
+
+    def _is_idle_again() -> bool:
+        status = client.run(client.client.call("commands.engine.status", {}))
+        return status["state"] == "idle"
+
+    assert _pump_qt_until(lightfall_service.qapp, _is_idle_again, timeout=30), \
+        "engine never returned to idle -- long raster leaked into next test"

--- a/tests/remote/test_e2e_gui.py
+++ b/tests/remote/test_e2e_gui.py
@@ -1,0 +1,223 @@
+"""Golden-run e2e: offscreen Qt, real RemoteBackend + real MainController
+against a REAL RemoteControlService + real NATS + real sim fleet + real
+Tiled (spec #4 Task 8).
+
+QT_QPA_PLATFORM=offscreen is set by the runner (see task brief); this file
+adds no platform wiring of its own. Generous timeouts throughout -- the
+whole module may take ~1-2 minutes against real EPICS/NATS/Tiled.
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+from PySide6 import QtCore
+
+from pystxmcontrol.gui.controllers.main_controller import MainController
+from pystxmcontrol.remote.client import LightfallClient
+from pystxmcontrol.remote.qt_bridge import RemoteBackend
+
+
+@pytest.fixture
+def qapp(lightfall_service):
+    # Reuse the session-wide QApplication the service fixture already made;
+    # constructing a second QApplication in the same process is invalid.
+    return lightfall_service.qapp
+
+
+def _pump_qt_until(qapp, predicate, timeout=60.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        # A longer sleep than the usual 0.02s Qt-pump idiom is deliberate:
+        # this test's background RunStreamer thread does real HTTP I/O that
+        # competes for the GIL with this loop, and a near-continuous
+        # processEvents()-then-sleep(0.02) busy-loop starves that thread of
+        # scheduling opportunities badly enough, in this environment, to
+        # stall it indefinitely (observed: no exception, no server-side
+        # request even logged, for minutes). 0.1s still pumps Qt responsively
+        # for a test whose waits are measured in tens of seconds.
+        time.sleep(0.3)
+    return False
+
+
+_GUI_APP_NAME = "stxm-remote-gui-test"
+
+
+@pytest.fixture
+def gui_client(lightfall_service):
+    # TrustManager only pre-approves the app_name lightfall_service itself
+    # used ("stxm-remote-test"); a different client identity is untrusted by
+    # default and the auth handshake would otherwise hang/deny silently.
+    lightfall_service.trust.approve(_GUI_APP_NAME)
+    return LightfallClient(
+        lightfall_service.ipc._nats_url,  # noqa: SLF001 - test-only introspection
+        lightfall_service.prefix,
+        _GUI_APP_NAME,
+    )
+
+
+@pytest.fixture
+def backend(qapp, gui_client):
+    be = RemoteBackend(gui_client)
+    be.start()
+    yield be
+    be.shutdown()
+    be.wait(5000)
+
+
+@pytest.fixture
+def controller(qapp, backend):
+    ctrl = MainController(backend=backend)
+    yield ctrl
+
+
+def _image_region(x_center, y_center, x_range, y_range, x_points, y_points):
+    x_step = x_range / x_points
+    y_step = y_range / y_points
+    return {
+        "xCenter": x_center, "yCenter": y_center,
+        "xRange": x_range, "yRange": y_range,
+        "xPoints": x_points, "yPoints": y_points,
+        "xStep": x_step, "yStep": y_step,
+        "xStart": x_center - x_range / 2.0 + x_step / 2.0,
+        "xStop": x_center + x_range / 2.0 - x_step / 2.0,
+        "yStart": y_center - y_range / 2.0 + y_step / 2.0,
+        "yStop": y_center + y_range / 2.0 - y_step / 2.0,
+        "zCenter": 0, "zRange": 0, "zPoints": 1, "zStep": 0,
+        "zStart": 0, "zStop": 0,
+    }
+
+
+def _energy_region(start=280.0, stop=280.0, n_energies=1, dwell=5.0, step=1.0):
+    return {"start": start, "stop": stop, "step": step, "dwell": dwell,
+            "n_energies": n_energies}
+
+
+# Small enough that a real fly-raster over the sim fleet finishes quickly,
+# but with >1 row so run-progress / partial-image behavior is exercised.
+# _NX must exceed bluesky_tiled_plugins.writing.tiled_writer.MAX_ARRAY_SIZE
+# (16): below that threshold the per-row array columns (X positions,
+# detector counts) are embedded as list-type columns in the "internal" SQL
+# table instead of routed to the zarr array-write path, and this fixture's
+# Tiled server uses sqlite storage (see conftest.py's lightfall_service),
+# whose dialect has no list column type.
+_NX, _NY = 20, 3
+
+
+def _make_small_raster_scan_model(controller):
+    controller.scan_model.set("scan_type", "Image")
+    controller.scan_model.set("x_motor", "SampleX")
+    controller.scan_model.set("y_motor", "SampleY")
+    controller.scan_model.set(
+        "scan_regions",
+        {"Region1": _image_region(0.0, 0.0, 4.0, 3.0, _NX, _NY)},
+    )
+    controller.scan_model.set(
+        "energy_regions", {"EnergyRegion1": _energy_region(dwell=5.0)}
+    )
+
+
+def test_golden_run_raster_end_to_end(qapp, lightfall_service, controller):
+    """The full loop: initialize -> submit raster -> image streams from Tiled
+    -> motor panel tracks a commanded move -> run completes."""
+    config_events: list[dict] = []
+    controller.status_updated.connect(lambda *_: None)  # keep Qt busy-safe
+    image_events: list[np.ndarray] = []
+    controller.image_updated.connect(lambda img: image_events.append(np.asarray(img)))
+
+    def _on_config_ready(cfg):
+        config_events.append(cfg)
+
+    controller.backend.config_ready.connect(_on_config_ready)
+
+    # ---- 1. initialize -> config_ready --------------------------------
+    assert controller.initialize_client() is True
+    assert _pump_qt_until(qapp, lambda: len(config_events) >= 1, timeout=30), \
+        "config_ready never fired"
+    config = config_events[0]
+    assert {"SampleX", "SampleY", "energy"} <= set(config["motors"])
+    assert any(p.get("name") == "stxm_fly_raster" for p in config["plans"])
+    assert _pump_qt_until(
+        qapp, lambda: controller.motor_model.get("motor_info") == {
+            "SampleX": {}, "SampleY": {}, "energy": {}},
+        timeout=15,
+    )
+
+    # ---- 2. motor panel tracks a commanded move_motor -------------------
+    controller.motor_model.set_motor_info({
+        "SampleY": {"minValue": -50, "maxValue": 50,
+                    "minScanValue": -50, "maxScanValue": 50},
+    })
+    position_events: list[tuple[str, float]] = []
+    controller.motor_position_updated.connect(
+        lambda name, pos: position_events.append((name, pos)))
+
+    target = 1.5
+    assert controller.move_motor("SampleY", target) is True
+    assert _pump_qt_until(
+        qapp,
+        lambda: any(name == "SampleY" and pos == pytest.approx(target, abs=0.05)
+                    for name, pos in position_events),
+        timeout=20,
+    ), f"motor panel never observed the commanded move; saw {position_events}"
+
+    # ---- 3. submit a small fly raster via start_scan() -------------------
+    _make_small_raster_scan_model(controller)
+    scan_state_events: list[bool] = []
+    controller.scan_state_changed.connect(lambda v: scan_state_events.append(v))
+    run_new_events: list[dict] = []
+    controller.backend.run_new.connect(lambda payload: run_new_events.append(payload))
+
+    assert controller.start_scan() is True
+    assert controller.scanning is True
+    assert _pump_qt_until(qapp, lambda: True in scan_state_events, timeout=15), \
+        "scan_state_changed(True) never fired"
+
+    # ---- 4. run_new -> RunStreamer assembles the image from Tiled --------
+    assert _pump_qt_until(qapp, lambda: len(run_new_events) >= 1, timeout=30), \
+        "runs.new was never broadcast for the submitted raster"
+    run_uid = run_new_events[0]["run_uid"]
+    assert run_uid
+
+    # Tiled reads racing the writer's concurrent node creation have been
+    # observed, in this environment, to self-heal only after a long run of
+    # internal client-side retries (the tiled HTTP client's own
+    # retry_context()/stamina backoff, well outside RunStreamer's control) --
+    # up to roughly a minute in the slowest observed case. Generous timeout.
+    assert _pump_qt_until(qapp, lambda: len(image_events) >= 1, timeout=90), \
+        "image_updated never fired from the real Tiled-backed RunStreamer"
+
+    # ---- 5. run_complete -> scanning becomes False ------------------------
+    assert _pump_qt_until(qapp, lambda: controller.scanning is False, timeout=180), \
+        "run never completed (controller.scanning stayed True)"
+    assert False in scan_state_events
+
+    # ---- 6. final image: shape (ny, nx), all-finite, matches Tiled --------
+    final_image = image_events[-1]
+    assert final_image.shape == (_NY, _NX)
+    assert np.isfinite(final_image).all(), \
+        f"final image has non-finite values: {final_image}"
+
+    # Independent read-back: a *separate* Tiled client (not the one wired
+    # into the RunStreamer/TiledWriter machinery) fetches the same run and
+    # its primary stream, and the image is reassembled by hand from that
+    # table -- proving the GUI's image is not just an artifact of internal
+    # state but genuinely reflects what landed in Tiled.
+    from tiled.client import from_uri
+
+    independent_client = from_uri(
+        lightfall_service.tiled_url, api_key=lightfall_service.tiled_token)
+    try:
+        run = independent_client[run_uid]
+        table = run["primary"].read()
+        column = table["STXMLineFlyer"]
+        assert len(column) == _NY
+        expected = np.stack([np.asarray(row, dtype=float) for row in column])
+        assert expected.shape == (_NY, _NX)
+        np.testing.assert_allclose(final_image, expected)
+    finally:
+        independent_client.context.close()

--- a/tests/remote/test_qt_bridge.py
+++ b/tests/remote/test_qt_bridge.py
@@ -1,0 +1,301 @@
+"""Tests for RemoteBackend (QThread + asyncio bridge), spec #4 Task 5."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from PySide6 import QtCore
+
+from pystxmcontrol.remote.client import RemoteError
+from pystxmcontrol.remote.qt_bridge import RemoteBackend
+
+
+class FakeLightfallClient:
+    """Duck-types the async surface RemoteBackend consumes; canned replies."""
+
+    def __init__(self):
+        self.session_token = None
+        self.tiled_url = None
+        self.tiled_token = None
+        self.call_log: list[tuple[str, dict]] = []
+        self.subscriptions: dict[str, callable] = {}
+        self.call_handlers: dict[str, callable] = {}
+        self.connected = False
+        self.closed = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def authenticate(self, timeout: float = 90.0) -> dict:
+        self.session_token = "tok123"
+        self.tiled_url = "http://tiled"
+        self.tiled_token = "tt"
+        return {"status": "approved", "session_token": "tok123"}
+
+    async def call(self, suffix: str, payload: dict | None = None, timeout: float = 5.0) -> dict:
+        payload = dict(payload or {})
+        self.call_log.append((suffix, payload))
+        handler = self.call_handlers.get(suffix)
+        if handler is not None:
+            return handler(payload)
+        return {"status": "ok"}
+
+    async def subscribe_event(self, suffix: str, callback) -> None:
+        self.subscriptions[suffix] = callback
+
+    async def close(self) -> None:
+        self.closed = True
+
+    # test helper: fire a broadcast event as if received off the wire
+    def fire(self, suffix: str, payload: dict) -> None:
+        cb = self.subscriptions[suffix]
+        cb(payload)
+
+
+class FakeMonitorSet:
+    """Stand-in for MotorMonitorSet -- injected via monitor_factory."""
+
+    instances: list["FakeMonitorSet"] = []
+
+    def __init__(self, motors, on_update, min_period_s: float = 0.2):
+        self.motors = motors
+        self.on_update = on_update
+        self.started = False
+        self.stopped = False
+        FakeMonitorSet.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture(autouse=True)
+def _clear_monitor_instances():
+    FakeMonitorSet.instances.clear()
+    yield
+    FakeMonitorSet.instances.clear()
+
+
+@pytest.fixture
+def qapp():
+    app = QtCore.QCoreApplication.instance()
+    if app is None:
+        app = QtCore.QCoreApplication([])
+    return app
+
+
+def _wait_for(qapp, predicate, timeout_s: float = 5.0) -> bool:
+    import time
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        qapp.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.01)
+    qapp.processEvents()
+    return predicate()
+
+
+@pytest.fixture
+def fake_client():
+    return FakeLightfallClient()
+
+
+@pytest.fixture
+def backend(qapp, fake_client):
+    backend = RemoteBackend(fake_client, monitor_factory=FakeMonitorSet)
+    backend.start()
+    yield backend
+    backend.shutdown()
+    backend.wait(5000)
+
+
+def test_connect_and_authenticate_emits_authenticated(qapp, backend):
+    events = []
+    backend.authenticated.connect(lambda d: events.append(d))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: len(events) == 1)
+    assert events[0]["status"] == "approved"
+
+
+def test_fetch_config_emits_config_ready_with_motors_filtered(qapp, backend, fake_client):
+    fake_client.call_handlers["device.search"] = lambda p: {
+        "status": "ok", "devices": ["SampleX", "SampleY", "Shutter"]}
+
+    def _info(payload):
+        device = payload["device"]
+        table = {
+            "SampleX": {"pv": "STXM:SampleX", "category": "motor"},
+            "SampleY": {"pv": "STXM:SampleY", "category": "motor"},
+            "Shutter": {"pv": "STXM:Shutter", "category": "shutter"},
+        }
+        return {"status": "ok", **table[device]}
+
+    fake_client.call_handlers["device.info"] = _info
+    fake_client.call_handlers["plan.list"] = lambda p: {
+        "status": "ok", "plans": ["stxm_fly_raster", "stxm_energy_stack"]}
+
+    events = []
+    backend.config_ready.connect(lambda d: events.append(d))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.fetch_config()
+    assert _wait_for(qapp, lambda: len(events) == 1)
+    config = events[0]
+    assert set(config["motors"]) == {"SampleX", "SampleY"}
+    assert config["motors"]["SampleX"]["pv"] == "STXM:SampleX"
+    assert config["plans"] == ["stxm_fly_raster", "stxm_energy_stack"]
+    # MotorMonitorSet started with the fetched PVs after config_ready
+    assert _wait_for(qapp, lambda: len(FakeMonitorSet.instances) == 1)
+    monitor = FakeMonitorSet.instances[0]
+    assert monitor.started
+    assert monitor.motors == {"SampleX": "STXM:SampleX", "SampleY": "STXM:SampleY"}
+
+
+def test_motor_positions_relayed_from_monitor(qapp, backend, fake_client):
+    fake_client.call_handlers["device.search"] = lambda p: {
+        "status": "ok", "devices": ["SampleX"]}
+    fake_client.call_handlers["device.info"] = lambda p: {
+        "status": "ok", "pv": "STXM:SampleX", "category": "motor"}
+    fake_client.call_handlers["plan.list"] = lambda p: {"status": "ok", "plans": []}
+
+    positions = []
+    backend.motor_positions.connect(lambda d: positions.append(d))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.fetch_config()
+    assert _wait_for(qapp, lambda: len(FakeMonitorSet.instances) == 1)
+    monitor = FakeMonitorSet.instances[0]
+    monitor.on_update({"SampleX": 1.5, "status": {"SampleX": False}})
+    assert _wait_for(qapp, lambda: len(positions) == 1)
+    assert positions[0]["SampleX"] == 1.5
+
+
+def test_submit_scan_happy_path_calls_plan_run_with_mapped_params(qapp, backend, fake_client):
+    fake_client.call_handlers["plan.run"] = lambda p: {"status": "ok", "run_id": "r1"}
+    scan = {
+        "scan_type": "Image",
+        "scan_regions": {"r1": {
+            "xStart": 0.0, "xStop": 1.0, "xPoints": 10,
+            "yStart": 0.0, "yStop": 1.0, "yPoints": 10}},
+        "energy_regions": {"e1": {"start": 500, "stop": 500, "n_energies": 1, "dwell": 5}},
+    }
+    events = []
+    backend.scan_submitted.connect(lambda d: events.append(d))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.submit_scan(scan)
+    assert _wait_for(qapp, lambda: len(events) == 1)
+    suffix, payload = fake_client.call_log[-1]
+    assert suffix == "plan.run"
+    assert payload["plan_name"] == "stxm_fly_raster"
+    assert payload["behavior"] == "reject"
+    assert payload["params"]["nx"] == 10
+
+
+def test_submit_scan_unsupported_mode_emits_scan_error(qapp, backend, fake_client):
+    scan = {"scan_type": "Ptychography", "scan_regions": {}, "energy_regions": {}}
+    errors = []
+    backend.scan_error.connect(lambda m: errors.append(m))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.submit_scan(scan)
+    assert _wait_for(qapp, lambda: len(errors) == 1)
+    assert "Ptychography" in errors[0]
+    assert not fake_client.call_log or fake_client.call_log[-1][0] != "plan.run"
+
+
+def test_submit_scan_busy_remote_error_emits_scan_error_no_crash(qapp, backend, fake_client):
+    def _busy(payload):
+        raise RemoteError("busy", "engine busy")
+
+    fake_client.call_handlers["plan.run"] = _busy
+    scan = {
+        "scan_type": "Image",
+        "scan_regions": {"r1": {
+            "xStart": 0.0, "xStop": 1.0, "xPoints": 5,
+            "yStart": 0.0, "yStop": 1.0, "yPoints": 5}},
+        "energy_regions": {"e1": {"start": 500, "stop": 500, "n_energies": 1, "dwell": 5}},
+    }
+    errors = []
+    backend.scan_error.connect(lambda m: errors.append(m))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.submit_scan(scan)
+    assert _wait_for(qapp, lambda: len(errors) == 1)
+    assert "engine busy" in errors[0]
+    # thread stays alive / responsive after the error
+    positions = []
+    backend.authenticated.connect(lambda d: positions.append(d))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: len(positions) == 1)
+
+
+def test_move_motor_limits_error_emits_remote_error(qapp, backend, fake_client):
+    def _limits(payload):
+        raise RemoteError("limits", "target outside soft limits")
+
+    fake_client.call_handlers["device.put"] = _limits
+    errors = []
+    backend.remote_error.connect(lambda m: errors.append(m))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.move_motor("SampleX", 42.0)
+    assert _wait_for(qapp, lambda: len(errors) == 1)
+    assert "target outside soft limits" in errors[0]
+
+
+def test_move_motor_happy_path_calls_device_put(qapp, backend, fake_client):
+    fake_client.call_handlers["device.put"] = lambda p: {"status": "ok"}
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.move_motor("SampleX", 3.5)
+
+    def _called():
+        return any(s == "device.put" for s, _ in fake_client.call_log)
+
+    assert _wait_for(qapp, _called)
+    suffix, payload = [c for c in fake_client.call_log if c[0] == "device.put"][-1]
+    assert payload["device"] == "SampleX"
+    assert payload["value"] == 3.5
+    assert payload["wait"] is True
+
+
+def test_runs_new_event_emits_run_new_signal(qapp, backend, fake_client):
+    events = []
+    backend.run_new.connect(lambda d: events.append(d))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    assert _wait_for(qapp, lambda: "runs.new" in fake_client.subscriptions)
+    fake_client.fire("runs.new", {"uid": "abc"})
+    assert _wait_for(qapp, lambda: len(events) == 1)
+    assert events[0]["uid"] == "abc"
+
+
+def test_runs_complete_and_engine_state_events(qapp, backend, fake_client):
+    completes = []
+    states = []
+    backend.run_complete.connect(lambda d: completes.append(d))
+    backend.engine_state.connect(lambda s: states.append(s))
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    assert _wait_for(qapp, lambda: "runs.complete" in fake_client.subscriptions)
+    assert _wait_for(qapp, lambda: "state.engine" in fake_client.subscriptions)
+    fake_client.fire("runs.complete", {"uid": "abc", "exit_status": "success"})
+    fake_client.fire("state.engine", {"state": "running"})
+    assert _wait_for(qapp, lambda: len(completes) == 1 and len(states) == 1)
+    assert completes[0]["exit_status"] == "success"
+    assert states[0] == "running"
+
+
+def test_shutdown_joins_thread_cleanly(qapp, fake_client):
+    backend = RemoteBackend(fake_client, monitor_factory=FakeMonitorSet)
+    backend.start()
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.shutdown()
+    assert backend.wait(5000)
+    assert not backend.isRunning()

--- a/tests/remote/test_qt_bridge.py
+++ b/tests/remote/test_qt_bridge.py
@@ -291,6 +291,61 @@ def test_runs_complete_and_engine_state_events(qapp, backend, fake_client):
     assert states[0] == "running"
 
 
+def test_shutdown_immediately_after_start_joins_thread(qapp, fake_client):
+    """shutdown() racing run()'s loop assignment must still stop the thread."""
+    backend = RemoteBackend(fake_client, monitor_factory=FakeMonitorSet)
+    backend.start()
+    assert backend.shutdown() is True
+    assert not backend.isRunning()
+
+
+def test_shutdown_before_start_is_clean(qapp, fake_client):
+    backend = RemoteBackend(fake_client, monitor_factory=FakeMonitorSet)
+    assert backend.shutdown() is True
+    assert not backend.isRunning()
+
+
+def test_monitor_not_started_when_shutdown_interleaves_fetch_config(qapp, fake_client):
+    """A fetch_config in flight during shutdown must not leak a started
+    monitor: the factory blocks until shutdown has begun, then _start_monitor
+    must refuse to start it (or stop it)."""
+    import time
+
+    fake_client.call_handlers["device.search"] = lambda p: {
+        "status": "ok", "devices": ["SampleX"]}
+    fake_client.call_handlers["device.info"] = lambda p: {
+        "status": "ok", "pv": "STXM:SampleX", "category": "motor"}
+    fake_client.call_handlers["plan.list"] = lambda p: {"status": "ok", "plans": []}
+
+    holder = {}
+    constructing = __import__("threading").Event()
+
+    class LatchedMonitor(FakeMonitorSet):
+        def __init__(self, motors, on_update, min_period_s=0.2):
+            constructing.set()
+            # Block construction (on the loop thread) until shutdown began,
+            # guaranteeing the shutdown-vs-start interleaving under test.
+            deadline = time.monotonic() + 5.0
+            while not holder["backend"]._shutting_down:
+                if time.monotonic() > deadline:
+                    raise AssertionError("shutdown never began")
+                time.sleep(0.005)
+            super().__init__(motors, on_update, min_period_s)
+
+    backend = RemoteBackend(fake_client, monitor_factory=LatchedMonitor)
+    holder["backend"] = backend
+    backend.start()
+    backend.connect_and_authenticate()
+    assert _wait_for(qapp, lambda: fake_client.session_token is not None)
+    backend.fetch_config()
+    assert constructing.wait(5.0)
+    assert backend.shutdown() is True
+    assert not backend.isRunning()
+    # The interleaved monitor must never remain started.
+    for monitor in FakeMonitorSet.instances:
+        assert not monitor.started or monitor.stopped
+
+
 def test_shutdown_joins_thread_cleanly(qapp, fake_client):
     backend = RemoteBackend(fake_client, monitor_factory=FakeMonitorSet)
     backend.start()

--- a/tests/remote/test_qt_bridge.py
+++ b/tests/remote/test_qt_bridge.py
@@ -21,9 +21,14 @@ def _clear_monitor_instances():
 
 @pytest.fixture
 def qapp():
+    # Full QApplication (not QCoreApplication): test_qt_integration's
+    # window-construction test needs widgets, and whichever test file runs
+    # first fixes the application type for the whole process.
+    from PySide6 import QtWidgets
+
     app = QtCore.QCoreApplication.instance()
     if app is None:
-        app = QtCore.QCoreApplication([])
+        app = QtWidgets.QApplication([])
     return app
 
 

--- a/tests/remote/test_qt_bridge.py
+++ b/tests/remote/test_qt_bridge.py
@@ -68,7 +68,7 @@ def test_connect_and_authenticate_emits_authenticated(qapp, backend):
 
 
 def test_fetch_config_emits_config_ready_with_motors_filtered(qapp, backend, fake_client):
-    fake_client.call_handlers["device.search"] = lambda p: {
+    fake_client.call_handlers["commands.device.search"] = lambda p: {
         "status": "ok", "devices": ["SampleX", "SampleY", "Shutter"]}
 
     def _info(payload):
@@ -80,8 +80,8 @@ def test_fetch_config_emits_config_ready_with_motors_filtered(qapp, backend, fak
         }
         return {"status": "ok", **table[device]}
 
-    fake_client.call_handlers["device.info"] = _info
-    fake_client.call_handlers["plan.list"] = lambda p: {
+    fake_client.call_handlers["commands.device.info"] = _info
+    fake_client.call_handlers["commands.plan.list"] = lambda p: {
         "status": "ok", "plans": ["stxm_fly_raster", "stxm_energy_stack"]}
 
     events = []
@@ -102,11 +102,11 @@ def test_fetch_config_emits_config_ready_with_motors_filtered(qapp, backend, fak
 
 
 def test_motor_positions_relayed_from_monitor(qapp, backend, fake_client):
-    fake_client.call_handlers["device.search"] = lambda p: {
+    fake_client.call_handlers["commands.device.search"] = lambda p: {
         "status": "ok", "devices": ["SampleX"]}
-    fake_client.call_handlers["device.info"] = lambda p: {
+    fake_client.call_handlers["commands.device.info"] = lambda p: {
         "status": "ok", "pv": "STXM:SampleX", "category": "motor"}
-    fake_client.call_handlers["plan.list"] = lambda p: {"status": "ok", "plans": []}
+    fake_client.call_handlers["commands.plan.list"] = lambda p: {"status": "ok", "plans": []}
 
     positions = []
     backend.motor_positions.connect(lambda d: positions.append(d))
@@ -121,7 +121,7 @@ def test_motor_positions_relayed_from_monitor(qapp, backend, fake_client):
 
 
 def test_submit_scan_happy_path_calls_plan_run_with_mapped_params(qapp, backend, fake_client):
-    fake_client.call_handlers["plan.run"] = lambda p: {"status": "ok", "run_id": "r1"}
+    fake_client.call_handlers["commands.plan.run"] = lambda p: {"status": "ok", "run_id": "r1"}
     scan = {
         "scan_type": "Image",
         "scan_regions": {"r1": {
@@ -136,7 +136,7 @@ def test_submit_scan_happy_path_calls_plan_run_with_mapped_params(qapp, backend,
     backend.submit_scan(scan)
     assert _wait_for(qapp, lambda: len(events) == 1)
     suffix, payload = fake_client.call_log[-1]
-    assert suffix == "plan.run"
+    assert suffix == "commands.plan.run"
     assert payload["plan_name"] == "stxm_fly_raster"
     assert payload["behavior"] == "reject"
     assert payload["params"]["nx"] == 10
@@ -151,14 +151,14 @@ def test_submit_scan_unsupported_mode_emits_scan_error(qapp, backend, fake_clien
     backend.submit_scan(scan)
     assert _wait_for(qapp, lambda: len(errors) == 1)
     assert "Ptychography" in errors[0]
-    assert not fake_client.call_log or fake_client.call_log[-1][0] != "plan.run"
+    assert not fake_client.call_log or fake_client.call_log[-1][0] != "commands.plan.run"
 
 
 def test_submit_scan_busy_remote_error_emits_scan_error_no_crash(qapp, backend, fake_client):
     def _busy(payload):
         raise RemoteError("busy", "engine busy")
 
-    fake_client.call_handlers["plan.run"] = _busy
+    fake_client.call_handlers["commands.plan.run"] = _busy
     scan = {
         "scan_type": "Image",
         "scan_regions": {"r1": {
@@ -184,7 +184,7 @@ def test_move_motor_limits_error_emits_remote_error(qapp, backend, fake_client):
     def _limits(payload):
         raise RemoteError("limits", "target outside soft limits")
 
-    fake_client.call_handlers["device.put"] = _limits
+    fake_client.call_handlers["commands.device.put"] = _limits
     errors = []
     backend.remote_error.connect(lambda m: errors.append(m))
     backend.connect_and_authenticate()
@@ -195,16 +195,16 @@ def test_move_motor_limits_error_emits_remote_error(qapp, backend, fake_client):
 
 
 def test_move_motor_happy_path_calls_device_put(qapp, backend, fake_client):
-    fake_client.call_handlers["device.put"] = lambda p: {"status": "ok"}
+    fake_client.call_handlers["commands.device.put"] = lambda p: {"status": "ok"}
     backend.connect_and_authenticate()
     assert _wait_for(qapp, lambda: fake_client.session_token is not None)
     backend.move_motor("SampleX", 3.5)
 
     def _called():
-        return any(s == "device.put" for s, _ in fake_client.call_log)
+        return any(s == "commands.device.put" for s, _ in fake_client.call_log)
 
     assert _wait_for(qapp, _called)
-    suffix, payload = [c for c in fake_client.call_log if c[0] == "device.put"][-1]
+    suffix, payload = [c for c in fake_client.call_log if c[0] == "commands.device.put"][-1]
     assert payload["device"] == "SampleX"
     assert payload["value"] == 3.5
     assert payload["wait"] is True
@@ -257,11 +257,11 @@ def test_monitor_not_started_when_shutdown_interleaves_fetch_config(qapp, fake_c
     must refuse to start it (or stop it)."""
     import time
 
-    fake_client.call_handlers["device.search"] = lambda p: {
+    fake_client.call_handlers["commands.device.search"] = lambda p: {
         "status": "ok", "devices": ["SampleX"]}
-    fake_client.call_handlers["device.info"] = lambda p: {
+    fake_client.call_handlers["commands.device.info"] = lambda p: {
         "status": "ok", "pv": "STXM:SampleX", "category": "motor"}
-    fake_client.call_handlers["plan.list"] = lambda p: {"status": "ok", "plans": []}
+    fake_client.call_handlers["commands.plan.list"] = lambda p: {"status": "ok", "plans": []}
 
     holder = {}
     constructing = __import__("threading").Event()

--- a/tests/remote/test_qt_bridge.py
+++ b/tests/remote/test_qt_bridge.py
@@ -9,66 +9,7 @@ from PySide6 import QtCore
 from pystxmcontrol.remote.client import RemoteError
 from pystxmcontrol.remote.qt_bridge import RemoteBackend
 
-
-class FakeLightfallClient:
-    """Duck-types the async surface RemoteBackend consumes; canned replies."""
-
-    def __init__(self):
-        self.session_token = None
-        self.tiled_url = None
-        self.tiled_token = None
-        self.call_log: list[tuple[str, dict]] = []
-        self.subscriptions: dict[str, callable] = {}
-        self.call_handlers: dict[str, callable] = {}
-        self.connected = False
-        self.closed = False
-
-    async def connect(self) -> None:
-        self.connected = True
-
-    async def authenticate(self, timeout: float = 90.0) -> dict:
-        self.session_token = "tok123"
-        self.tiled_url = "http://tiled"
-        self.tiled_token = "tt"
-        return {"status": "approved", "session_token": "tok123"}
-
-    async def call(self, suffix: str, payload: dict | None = None, timeout: float = 5.0) -> dict:
-        payload = dict(payload or {})
-        self.call_log.append((suffix, payload))
-        handler = self.call_handlers.get(suffix)
-        if handler is not None:
-            return handler(payload)
-        return {"status": "ok"}
-
-    async def subscribe_event(self, suffix: str, callback) -> None:
-        self.subscriptions[suffix] = callback
-
-    async def close(self) -> None:
-        self.closed = True
-
-    # test helper: fire a broadcast event as if received off the wire
-    def fire(self, suffix: str, payload: dict) -> None:
-        cb = self.subscriptions[suffix]
-        cb(payload)
-
-
-class FakeMonitorSet:
-    """Stand-in for MotorMonitorSet -- injected via monitor_factory."""
-
-    instances: list["FakeMonitorSet"] = []
-
-    def __init__(self, motors, on_update, min_period_s: float = 0.2):
-        self.motors = motors
-        self.on_update = on_update
-        self.started = False
-        self.stopped = False
-        FakeMonitorSet.instances.append(self)
-
-    def start(self) -> None:
-        self.started = True
-
-    def stop(self) -> None:
-        self.stopped = True
+from .fakes import FakeLightfallClient, FakeMonitorSet
 
 
 @pytest.fixture(autouse=True)

--- a/tests/remote/test_qt_integration.py
+++ b/tests/remote/test_qt_integration.py
@@ -217,6 +217,38 @@ def test_run_complete_stops_scanning_and_streamer(qapp, controller, backend, fak
     assert streamer.stopped is True
 
 
+def test_late_image_after_run_complete_keeps_scanning_false(
+        qapp, controller, backend, fake_client):
+    """Regression: a run's last image, delivered right after run_complete
+    cleared scanning, must NOT flip scanning back to True.
+
+    The RunStreamer emits images from a background thread; one can be queued
+    before the run_complete broadcast stops it and then delivered afterwards.
+    The legacy _on_external_scan_detected inference (image data -> "a scan is
+    running") would resurrect scanning=True and leave it stuck. In backend
+    mode the explicit run lifecycle is authoritative, so that inference is
+    disabled. This raced ~50/50 as an e2e flake before the fix.
+    """
+    controller.scanning = True
+    controller.initialize_client()
+    assert wait_for(qapp, lambda: "runs.new" in fake_client.subscriptions)
+    fake_client.fire("runs.new", {"run_uid": "run-late"})
+    assert wait_for(qapp, lambda: len(FakeRunStreamer.instances) == 1)
+    streamer = FakeRunStreamer.instances[0]
+
+    fake_client.fire("runs.complete", {"run_uid": "run-late", "exit_status": "success"})
+    assert wait_for(qapp, lambda: controller.scanning is False)
+
+    # A late image arrives after completion (streamer callback still bound).
+    img_events = []
+    controller.image_updated.connect(lambda im: img_events.append(im))
+    streamer.fire_image({"default": np.zeros((20, 10))})
+    assert wait_for(qapp, lambda: len(img_events) >= 1), \
+        "late image was never delivered — test would pass vacuously"
+    assert controller.scanning is False, \
+        "late image resurrected scanning (external-scan inference raced the lifecycle)"
+
+
 # ---------------------------------------------------------------------------
 # disabled-in-remote-mode surface
 # ---------------------------------------------------------------------------

--- a/tests/remote/test_qt_integration.py
+++ b/tests/remote/test_qt_integration.py
@@ -249,6 +249,29 @@ def test_late_image_after_run_complete_keeps_scanning_false(
         "late image resurrected scanning (external-scan inference raced the lifecycle)"
 
 
+def test_quit_application_shuts_down_backend(qapp, controller, backend, monkeypatch):
+    """quit_application must tear the backend down before sys.exit().
+
+    sys.exit() inside a Qt slot ends the process before app.exec() returns, so
+    app.py's post-loop cleanup never runs -- the graceful shutdown has to
+    happen in quit_application itself. Neutralize sys.exit so it doesn't kill
+    pytest, then assert the backend was actually shut down.
+    """
+    exits = []
+    monkeypatch.setattr(main_controller_mod.sys, "exit", lambda *a: exits.append(a))
+    shutdown_calls = []
+    real_shutdown = backend.shutdown
+    monkeypatch.setattr(
+        backend, "shutdown",
+        lambda: (shutdown_calls.append(True), real_shutdown())[1])
+
+    controller.quit_application()
+
+    assert shutdown_calls, "quit_application did not shut the backend down in remote mode"
+    assert exits, "sys.exit was not reached"
+    assert not backend.isRunning(), "backend thread still alive after quit_application"
+
+
 # ---------------------------------------------------------------------------
 # disabled-in-remote-mode surface
 # ---------------------------------------------------------------------------

--- a/tests/remote/test_qt_integration.py
+++ b/tests/remote/test_qt_integration.py
@@ -39,10 +39,25 @@ def _clear_fake_instances():
 
 @pytest.fixture
 def qapp():
+    # Full QApplication (not QCoreApplication): the window-construction test
+    # needs widgets, and whichever test file runs first fixes the app type
+    # for the whole process.
+    from PySide6 import QtWidgets
+
     app = QtCore.QCoreApplication.instance()
     if app is None:
-        app = QtCore.QCoreApplication([])
+        app = QtWidgets.QApplication([])
     return app
+
+
+@pytest.fixture
+def qapp_widgets(qapp):
+    from PySide6 import QtWidgets
+
+    if not isinstance(qapp, QtWidgets.QApplication):
+        pytest.skip("process QCoreApplication is not a QApplication; "
+                     "widget construction impossible in this run")
+    return qapp
 
 
 @pytest.fixture
@@ -205,6 +220,27 @@ def test_run_complete_stops_scanning_and_streamer(qapp, controller, backend, fak
 # ---------------------------------------------------------------------------
 # disabled-in-remote-mode surface
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# full-window construction tripwire (the stxmcontrol-remote entry point path)
+# ---------------------------------------------------------------------------
+
+def test_mainwindow_constructs_in_backend_mode(qapp_widgets, controller):
+    """Regression tripwire: MainWindowMVC must construct with a backend-mode
+    controller (client=None) -- exactly what app.py::main() does. Any
+    unguarded self.controller.client.* reach during __init__ crashes the
+    stxmcontrol-remote entry point before the window ever shows."""
+    from pystxmcontrol.gui.mainwindow_mvc import MainWindowMVC
+
+    window = MainWindowMVC(controller=controller)
+    try:
+        assert window.controller is controller
+        assert controller.backend is not None
+    finally:
+        window.close()
+        window.deleteLater()
+        qapp_widgets.processEvents()
+
 
 @pytest.mark.parametrize("method,args", [
     ("set_gate", ("auto",)),

--- a/tests/remote/test_qt_integration.py
+++ b/tests/remote/test_qt_integration.py
@@ -1,0 +1,221 @@
+"""Integration tests: real MainController + models driven by a
+FakeLightfallClient-backed RemoteBackend (spec #4 Task 7).
+
+Pins (see s4-task-7-report.md for the full writeup):
+  - motor_model.set_motor_info() is fed {motor_name: {}, ...} synthesized
+    from config_ready's {"motors": {name: {"pv":..., "category":...}}}.
+  - backend.motor_positions payload ({name: float, ..., "status": {name:
+    bool}}) is routed through _handle_monitor_message as
+    {"motorPositions": payload} -- the same shape the legacy ZMQ monitor
+    message carries under that key.
+  - RunStreamer.on_image(image_dict, extents) is synthesized into a message
+    dict handled by the existing image branch of _handle_monitor_message:
+    {"image": image_dict, "mode": "rasterLine", "type": "Image",
+    "scanRegion": "Region1", "energyIndex": 0, "scanID": run_uid}.
+  - run_complete drives _handle_monitor_message("scan_complete") (the same
+    sentinel the legacy path uses).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PySide6 import QtCore
+
+from pystxmcontrol.gui.controllers import main_controller as main_controller_mod
+from pystxmcontrol.gui.controllers.main_controller import MainController
+from pystxmcontrol.remote.qt_bridge import RemoteBackend
+
+from .fakes import FakeLightfallClient, FakeMonitorSet, FakeRunStreamer, wait_for
+
+
+@pytest.fixture(autouse=True)
+def _clear_fake_instances():
+    FakeMonitorSet.instances.clear()
+    FakeRunStreamer.instances.clear()
+    yield
+    FakeMonitorSet.instances.clear()
+    FakeRunStreamer.instances.clear()
+
+
+@pytest.fixture
+def qapp():
+    app = QtCore.QCoreApplication.instance()
+    if app is None:
+        app = QtCore.QCoreApplication([])
+    return app
+
+
+@pytest.fixture
+def fake_client():
+    return FakeLightfallClient()
+
+
+@pytest.fixture
+def backend(qapp, fake_client):
+    backend = RemoteBackend(fake_client, monitor_factory=FakeMonitorSet)
+    backend.start()
+    yield backend
+    backend.shutdown()
+    backend.wait(5000)
+
+
+@pytest.fixture
+def controller(qapp, backend, monkeypatch):
+    # RunStreamer is constructed inside main_controller on run_new; patch the
+    # module-level name so we can drive it without a real Tiled connection.
+    monkeypatch.setattr(main_controller_mod, "RunStreamer", FakeRunStreamer)
+    ctrl = MainController(backend=backend)
+    yield ctrl
+
+
+def _image_region(x_center=0.0, y_center=0.0, x_range=10.0, y_range=20.0,
+                   x_points=10, y_points=20):
+    x_step = x_range / x_points
+    y_step = y_range / y_points
+    return {
+        "xCenter": x_center, "yCenter": y_center,
+        "xRange": x_range, "yRange": y_range,
+        "xPoints": x_points, "yPoints": y_points,
+        "xStep": x_step, "yStep": y_step,
+        "xStart": x_center - x_range / 2.0 + x_step / 2.0,
+        "xStop": x_center + x_range / 2.0 - x_step / 2.0,
+        "yStart": y_center - y_range / 2.0 + y_step / 2.0,
+        "yStop": y_center + y_range / 2.0 - y_step / 2.0,
+        "zCenter": 0, "zRange": 0, "zPoints": 1, "zStep": 0,
+        "zStart": 0, "zStop": 0,
+    }
+
+
+def _energy_region(start=280.0, stop=280.0, n_energies=1, dwell=5.0, step=1.0):
+    return {"start": start, "stop": stop, "step": step, "dwell": dwell,
+            "n_energies": n_energies}
+
+
+def _make_raster_scan_model(controller):
+    controller.scan_model.set("scan_type", "Image")
+    controller.scan_model.set("x_motor", "SampleX")
+    controller.scan_model.set("y_motor", "SampleY")
+    controller.scan_model.set("scan_regions", {"Region1": _image_region()})
+    controller.scan_model.set("energy_regions", {"EnergyRegion1": _energy_region()})
+
+
+# ---------------------------------------------------------------------------
+# backend=None: legacy ZMQ path stays intact (import-only, no real server)
+# ---------------------------------------------------------------------------
+
+def test_backend_none_still_constructs_zmq_client(monkeypatch):
+    calls = []
+
+    class _DummyStxmClient:
+        def __init__(self):
+            calls.append("constructed")
+
+    monkeypatch.setattr(main_controller_mod, "stxm_client", _DummyStxmClient)
+    ctrl = MainController()
+    assert calls == ["constructed"]
+    assert ctrl.backend is None
+    assert isinstance(ctrl.client, _DummyStxmClient)
+
+
+# ---------------------------------------------------------------------------
+# backend mode: initialization
+# ---------------------------------------------------------------------------
+
+def test_initialize_client_populates_motor_model_from_config(qapp, controller, fake_client):
+    def _device_search(payload):
+        return {"devices": ["SampleX", "SampleY"]}
+
+    def _device_info(payload):
+        name = payload["device"]
+        return {"pv": f"STXMSIM:{name}", "category": "motor"}
+
+    fake_client.call_handlers["device.search"] = _device_search
+    fake_client.call_handlers["device.info"] = _device_info
+    fake_client.call_handlers["plan.list"] = lambda payload: {"plans": ["stxm_fly_raster"]}
+
+    assert controller.initialize_client() is True
+    assert wait_for(qapp, lambda: controller.motor_model.get("motor_info") == {
+        "SampleX": {}, "SampleY": {}})
+
+
+def test_move_motor_routes_to_device_put(qapp, controller, fake_client):
+    controller.motor_model.set_motor_info({"SampleX": {"minValue": -10, "maxValue": 10,
+                                                         "minScanValue": -10, "maxScanValue": 10}})
+    assert controller.move_motor("SampleX", 1.5) is True
+    assert wait_for(qapp, lambda: ("device.put", {"device": "SampleX", "value": 1.5, "wait": True})
+                     in fake_client.call_log)
+
+
+def test_start_scan_raster_routes_to_plan_run(qapp, controller, fake_client):
+    _make_raster_scan_model(controller)
+    assert controller.start_scan() is True
+    assert wait_for(qapp, lambda: any(suffix == "plan.run" for suffix, _ in fake_client.call_log))
+    suffix, payload = next(c for c in fake_client.call_log if c[0] == "plan.run")
+    assert payload["plan_name"] == "stxm_fly_raster"
+
+
+def test_busy_scan_emits_error_occurred(qapp, controller):
+    _make_raster_scan_model(controller)
+    controller.scanning = True
+    events = []
+    controller.error_occurred.connect(lambda msg: events.append(msg))
+    assert controller.start_scan() is False
+    assert events == ["Scan already in progress"]
+
+
+# ---------------------------------------------------------------------------
+# run_new / run_complete -> RunStreamer -> image_model / scan_state
+# ---------------------------------------------------------------------------
+
+def test_run_new_starts_streamer_and_image_flows_to_image_model(qapp, controller, backend, fake_client):
+    events = []
+    controller.image_updated.connect(lambda img: events.append(img))
+
+    controller.initialize_client()
+    assert wait_for(qapp, lambda: "runs.new" in fake_client.subscriptions)
+    fake_client.fire("runs.new", {"uid": "run-1"})
+    assert wait_for(qapp, lambda: len(FakeRunStreamer.instances) == 1)
+    streamer = FakeRunStreamer.instances[0]
+    assert streamer.run_uid == "run-1"
+    assert streamer.started is True
+
+    image = np.zeros((20, 10))
+    streamer.fire_image({"default": image})
+    assert wait_for(qapp, lambda: len(events) >= 1)
+    assert np.array_equal(events[-1], image)
+
+
+def test_run_complete_stops_scanning_and_streamer(qapp, controller, backend, fake_client):
+    controller.scanning = True
+    controller.initialize_client()
+    assert wait_for(qapp, lambda: "runs.new" in fake_client.subscriptions)
+    fake_client.fire("runs.new", {"uid": "run-2"})
+    assert wait_for(qapp, lambda: len(FakeRunStreamer.instances) == 1)
+    streamer = FakeRunStreamer.instances[0]
+
+    state_events = []
+    controller.scan_state_changed.connect(lambda v: state_events.append(v))
+
+    fake_client.fire("runs.complete", {"uid": "run-2", "exit_status": "success"})
+    assert wait_for(qapp, lambda: controller.scanning is False)
+    assert wait_for(qapp, lambda: False in state_events)
+    assert streamer.stopped is True
+
+
+# ---------------------------------------------------------------------------
+# disabled-in-remote-mode surface
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("method,args", [
+    ("set_gate", ("auto",)),
+    ("move_to_focus", ()),
+    ("change_motor_config", ("SampleX", "offset", 1.0)),
+    ("query_motor_history", ("SampleX", 0.0, 1.0)),
+])
+def test_disabled_methods_emit_not_available(qapp, controller, method, args):
+    events = []
+    controller.status_updated.connect(lambda msg: events.append(msg))
+    result = getattr(controller, method)(*args)
+    assert wait_for(qapp, lambda: any("not available in remote mode" in m for m in events))
+    if method == "query_motor_history":
+        assert result == []

--- a/tests/remote/test_qt_integration.py
+++ b/tests/remote/test_qt_integration.py
@@ -144,9 +144,9 @@ def test_initialize_client_populates_motor_model_from_config(qapp, controller, f
         name = payload["device"]
         return {"pv": f"STXMSIM:{name}", "category": "motor"}
 
-    fake_client.call_handlers["device.search"] = _device_search
-    fake_client.call_handlers["device.info"] = _device_info
-    fake_client.call_handlers["plan.list"] = lambda payload: {"plans": ["stxm_fly_raster"]}
+    fake_client.call_handlers["commands.device.search"] = _device_search
+    fake_client.call_handlers["commands.device.info"] = _device_info
+    fake_client.call_handlers["commands.plan.list"] = lambda payload: {"plans": ["stxm_fly_raster"]}
 
     assert controller.initialize_client() is True
     assert wait_for(qapp, lambda: controller.motor_model.get("motor_info") == {
@@ -157,15 +157,15 @@ def test_move_motor_routes_to_device_put(qapp, controller, fake_client):
     controller.motor_model.set_motor_info({"SampleX": {"minValue": -10, "maxValue": 10,
                                                          "minScanValue": -10, "maxScanValue": 10}})
     assert controller.move_motor("SampleX", 1.5) is True
-    assert wait_for(qapp, lambda: ("device.put", {"device": "SampleX", "value": 1.5, "wait": True})
+    assert wait_for(qapp, lambda: ("commands.device.put", {"device": "SampleX", "value": 1.5, "wait": True})
                      in fake_client.call_log)
 
 
 def test_start_scan_raster_routes_to_plan_run(qapp, controller, fake_client):
     _make_raster_scan_model(controller)
     assert controller.start_scan() is True
-    assert wait_for(qapp, lambda: any(suffix == "plan.run" for suffix, _ in fake_client.call_log))
-    suffix, payload = next(c for c in fake_client.call_log if c[0] == "plan.run")
+    assert wait_for(qapp, lambda: any(suffix == "commands.plan.run" for suffix, _ in fake_client.call_log))
+    suffix, payload = next(c for c in fake_client.call_log if c[0] == "commands.plan.run")
     assert payload["plan_name"] == "stxm_fly_raster"
 
 
@@ -188,7 +188,7 @@ def test_run_new_starts_streamer_and_image_flows_to_image_model(qapp, controller
 
     controller.initialize_client()
     assert wait_for(qapp, lambda: "runs.new" in fake_client.subscriptions)
-    fake_client.fire("runs.new", {"uid": "run-1"})
+    fake_client.fire("runs.new", {"run_uid": "run-1"})
     assert wait_for(qapp, lambda: len(FakeRunStreamer.instances) == 1)
     streamer = FakeRunStreamer.instances[0]
     assert streamer.run_uid == "run-1"
@@ -204,14 +204,14 @@ def test_run_complete_stops_scanning_and_streamer(qapp, controller, backend, fak
     controller.scanning = True
     controller.initialize_client()
     assert wait_for(qapp, lambda: "runs.new" in fake_client.subscriptions)
-    fake_client.fire("runs.new", {"uid": "run-2"})
+    fake_client.fire("runs.new", {"run_uid": "run-2"})
     assert wait_for(qapp, lambda: len(FakeRunStreamer.instances) == 1)
     streamer = FakeRunStreamer.instances[0]
 
     state_events = []
     controller.scan_state_changed.connect(lambda v: state_events.append(v))
 
-    fake_client.fire("runs.complete", {"uid": "run-2", "exit_status": "success"})
+    fake_client.fire("runs.complete", {"run_uid": "run-2", "exit_status": "success"})
     assert wait_for(qapp, lambda: controller.scanning is False)
     assert wait_for(qapp, lambda: False in state_events)
     assert streamer.stopped is True

--- a/tests/remote/test_scan_mapping.py
+++ b/tests/remote/test_scan_mapping.py
@@ -1,0 +1,191 @@
+"""Tests for scan_mapping.map_scan.
+
+Test dicts are built to match the real shape produced by
+main_controller.compile_scan_from_view / _extract_scan_region_data /
+_extract_energy_region_data (pinned in pystxmcontrol/gui/models/scan_model.py
+and pystxmcontrol/gui/controllers/main_controller.py):
+
+- scan_regions[name] has xCenter/yCenter/xRange/yRange/xPoints/yPoints/
+  xStep/yStep/xStart/xStop/yStart/yStop/z* (Start/Stop already derived from
+  Center/Range/Points by the GUI).
+- energy_regions[name] has start/stop/step/dwell/n_energies (dwell is
+  milliseconds — ScanModel.calculate_estimated_time divides it by 1000.0).
+"""
+from __future__ import annotations
+
+import pytest
+
+from pystxmcontrol.remote.scan_mapping import UnsupportedScanMode, map_scan
+
+
+def _image_region(x_center=0.0, y_center=0.0, x_range=10.0, y_range=10.0,
+                   x_points=100, y_points=100):
+    x_step = x_range / x_points
+    y_step = y_range / y_points
+    return {
+        "xCenter": x_center, "yCenter": y_center,
+        "xRange": x_range, "yRange": y_range,
+        "xPoints": x_points, "yPoints": y_points,
+        "xStep": x_step, "yStep": y_step,
+        "xStart": x_center - x_range / 2.0 + x_step / 2.0,
+        "xStop": x_center + x_range / 2.0 - x_step / 2.0,
+        "yStart": y_center - y_range / 2.0 + y_step / 2.0,
+        "yStop": y_center + y_range / 2.0 - y_step / 2.0,
+        "zCenter": 0, "zRange": 0, "zPoints": 1, "zStep": 0,
+        "zStart": 0, "zStop": 0,
+    }
+
+
+def _energy_region(start=280.0, stop=280.0, n_energies=1, dwell=1000.0, step=1.0):
+    return {"start": start, "stop": stop, "step": step, "dwell": dwell,
+            "n_energies": n_energies}
+
+
+def _base_scan(scan_type="Image", scan_regions=None, energy_regions=None):
+    return {
+        "scan_type": scan_type,
+        "scan_regions": scan_regions if scan_regions is not None else {"Region1": _image_region()},
+        "energy_regions": energy_regions if energy_regions is not None else {"EnergyRegion1": _energy_region()},
+        "x_motor": "SampleX",
+        "y_motor": "SampleY",
+        "energy_motor": "Energy",
+        "single_energy": True,
+        "dwell": 1.0,
+    }
+
+
+# --- single-region, single-energy Image scan -> stxm_fly_raster ---
+
+def test_single_energy_image_scan_maps_to_fly_raster():
+    scan = _base_scan(
+        scan_regions={"Region1": _image_region(x_center=0.0, y_center=0.0,
+                                                 x_range=10.0, y_range=20.0,
+                                                 x_points=100, y_points=200)},
+        energy_regions={"EnergyRegion1": _energy_region(start=280.0, stop=280.0,
+                                                          n_energies=1, dwell=5.0)},
+    )
+    plan_name, params = map_scan(scan)
+    assert plan_name == "stxm_fly_raster"
+    region = scan["scan_regions"]["Region1"]
+    assert params == {
+        "y_start": region["yStart"], "y_stop": region["yStop"], "ny": 200,
+        "x_start": region["xStart"], "x_stop": region["xStop"], "nx": 100,
+        "dwell": 5.0,
+    }
+
+
+def test_fly_raster_dwell_is_milliseconds_passthrough():
+    scan = _base_scan(
+        energy_regions={"EnergyRegion1": _energy_region(dwell=12.5, n_energies=1)},
+    )
+    _, params = map_scan(scan)
+    assert params["dwell"] == 12.5
+
+
+# --- multi-energy Image scan -> stxm_energy_stack ---
+
+def test_multi_energy_image_scan_maps_to_energy_stack():
+    scan = _base_scan(
+        scan_regions={"Region1": _image_region(x_points=50, y_points=60)},
+        energy_regions={"EnergyRegion1": _energy_region(start=280.0, stop=282.0,
+                                                          n_energies=3, dwell=8.0)},
+    )
+    plan_name, params = map_scan(scan)
+    assert plan_name == "stxm_energy_stack"
+    assert params["energies"] == [280.0, 281.0, 282.0]
+    assert params["dwell_ms"] == 8.0
+    region = scan["scan_regions"]["Region1"]
+    assert params["nx"] == 50
+    assert params["ny"] == 60
+    assert params["x_start"] == region["xStart"]
+    assert params["y_stop"] == region["yStop"]
+
+
+def test_multiple_energy_regions_concatenate_in_order():
+    scan = _base_scan(
+        energy_regions={
+            "EnergyRegion1": _energy_region(start=280.0, stop=281.0, n_energies=2, dwell=10.0),
+            "EnergyRegion2": _energy_region(start=290.0, stop=290.0, n_energies=1, dwell=10.0),
+        },
+    )
+    plan_name, params = map_scan(scan)
+    assert plan_name == "stxm_energy_stack"
+    assert params["energies"] == [280.0, 281.0, 290.0]
+
+
+def test_energy_stack_uses_first_region_dwell():
+    scan = _base_scan(
+        energy_regions={
+            "EnergyRegion1": _energy_region(start=280.0, stop=281.0, n_energies=2, dwell=3.0),
+            "EnergyRegion2": _energy_region(start=290.0, stop=291.0, n_energies=2, dwell=99.0),
+        },
+    )
+    _, params = map_scan(scan)
+    assert params["dwell_ms"] == 3.0
+
+
+# --- unsupported scan modes ---
+
+@pytest.mark.parametrize("scan_type", [
+    "Ptychography",
+    "Focus",
+    "Line Spectrum",
+    "Single Motor",
+    "Double Motor",
+])
+def test_unsupported_scan_types_raise(scan_type):
+    scan = _base_scan(scan_type=scan_type)
+    with pytest.raises(UnsupportedScanMode) as excinfo:
+        map_scan(scan)
+    assert excinfo.value.scan_type == scan_type
+
+
+# --- missing keys ---
+
+def test_missing_scan_type_raises_key_error():
+    scan = _base_scan()
+    del scan["scan_type"]
+    with pytest.raises(KeyError, match="scan_type"):
+        map_scan(scan)
+
+
+def test_missing_scan_regions_raises_key_error():
+    scan = _base_scan()
+    del scan["scan_regions"]
+    with pytest.raises(KeyError, match="scan_regions"):
+        map_scan(scan)
+
+
+def test_empty_scan_regions_raises_key_error():
+    scan = _base_scan(scan_regions={})
+    with pytest.raises(KeyError, match="scan_regions"):
+        map_scan(scan)
+
+
+def test_missing_region_key_names_the_key():
+    region = _image_region()
+    del region["xStart"]
+    scan = _base_scan(scan_regions={"Region1": region})
+    with pytest.raises(KeyError, match="xStart"):
+        map_scan(scan)
+
+
+def test_missing_energy_regions_raises_key_error():
+    scan = _base_scan()
+    del scan["energy_regions"]
+    with pytest.raises(KeyError, match="energy_regions"):
+        map_scan(scan)
+
+
+def test_empty_energy_regions_raises_key_error():
+    scan = _base_scan(energy_regions={})
+    with pytest.raises(KeyError, match="energy_regions"):
+        map_scan(scan)
+
+
+def test_missing_energy_region_key_names_the_key():
+    region = _energy_region()
+    del region["dwell"]
+    scan = _base_scan(energy_regions={"EnergyRegion1": region})
+    with pytest.raises(KeyError, match="dwell"):
+        map_scan(scan)

--- a/tests/remote/test_scan_mapping.py
+++ b/tests/remote/test_scan_mapping.py
@@ -15,7 +15,11 @@ from __future__ import annotations
 
 import pytest
 
-from pystxmcontrol.remote.scan_mapping import UnsupportedScanMode, map_scan
+from pystxmcontrol.remote.scan_mapping import (
+    MultiRegionNotSupported,
+    UnsupportedScanMode,
+    map_scan,
+)
 
 
 def _image_region(x_center=0.0, y_center=0.0, x_range=10.0, y_range=10.0,
@@ -113,15 +117,38 @@ def test_multiple_energy_regions_concatenate_in_order():
     assert params["energies"] == [280.0, 281.0, 290.0]
 
 
-def test_energy_stack_uses_first_region_dwell():
+def test_differing_energy_region_dwells_raise():
     scan = _base_scan(
         energy_regions={
             "EnergyRegion1": _energy_region(start=280.0, stop=281.0, n_energies=2, dwell=3.0),
             "EnergyRegion2": _energy_region(start=290.0, stop=291.0, n_energies=2, dwell=99.0),
         },
     )
-    _, params = map_scan(scan)
-    assert params["dwell_ms"] == 3.0
+    with pytest.raises(UnsupportedScanMode, match="differing dwells.*3.0.*99.0"):
+        map_scan(scan)
+
+
+def test_multiple_energy_regions_same_dwell_ok():
+    scan = _base_scan(
+        energy_regions={
+            "EnergyRegion1": _energy_region(start=280.0, stop=281.0, n_energies=2, dwell=7.0),
+            "EnergyRegion2": _energy_region(start=290.0, stop=291.0, n_energies=2, dwell=7.0),
+        },
+    )
+    plan_name, params = map_scan(scan)
+    assert plan_name == "stxm_energy_stack"
+    assert params["dwell_ms"] == 7.0
+    assert params["energies"] == [280.0, 281.0, 290.0, 291.0]
+
+
+def test_multi_region_image_scan_raises_naming_regions():
+    scan = _base_scan(
+        scan_regions={"Region1": _image_region(), "Region2": _image_region(x_center=5.0)},
+    )
+    with pytest.raises(MultiRegionNotSupported, match="Region1, Region2") as excinfo:
+        map_scan(scan)
+    assert isinstance(excinfo.value, UnsupportedScanMode)
+    assert excinfo.value.scan_type == "Image"
 
 
 # --- unsupported scan modes ---

--- a/tests/remote/test_tiled_stream.py
+++ b/tests/remote/test_tiled_stream.py
@@ -1,0 +1,269 @@
+"""RunStreamer unit tests against a FakeRun/FakeStream (spec #4 Task 6).
+
+No Tiled server involved: FakeStream.read() returns a growing table
+(dict of column -> list) that mimics the primary stream table facet.
+Live coverage against a real Tiled server lands in Task 8.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from pystxmcontrol.remote.tiled_stream import RunStreamer
+
+
+def _wait_until(predicate, timeout=5.0, interval=0.01):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+class FakeStream:
+    """Duck-types the tiled stream node surface: only .read() is used."""
+
+    def __init__(self, table_fn=None, table=None, raise_exc=None):
+        self._table_fn = table_fn
+        self._table = table
+        self._raise_exc = raise_exc
+        self.read_count = 0
+
+    def read(self):
+        self.read_count += 1
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        if self._table_fn is not None:
+            return self._table_fn()
+        return self._table
+
+
+class FakeRun:
+    """Duck-types run.metadata["start"] + run["primary"]."""
+
+    def __init__(self, start_md, primary=None, primary_exc=None):
+        self.metadata = {"start": start_md}
+        self._primary = primary
+        self._primary_exc = primary_exc
+
+    def __getitem__(self, key):
+        if key != "primary":
+            raise KeyError(key)
+        if self._primary_exc is not None:
+            raise self._primary_exc
+        if self._primary is None:
+            raise KeyError("primary")
+        return self._primary
+
+
+def _raster_md(ny=3, nx=4):
+    return {
+        "plan_name": "stxm_fly_raster",
+        "shape": [ny, nx],
+        "x_extent": [0.0, 10.0],
+        "y_extent": [-5.0, 5.0],
+    }
+
+
+class _Collector:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.images = []
+        self.progress = []
+        self.errors = []
+
+    def on_image(self, images, extents):
+        with self.lock:
+            self.images.append((images, extents))
+
+    def on_progress(self, done, total):
+        with self.lock:
+            self.progress.append((done, total))
+
+    def on_error(self, exc):
+        with self.lock:
+            self.errors.append(exc)
+
+
+def _factory_for(run):
+    """RunStreamer calls ``factory() -> catalog`` then ``catalog[run_uid]``."""
+    return lambda: {"fake-uid": run}
+
+
+def test_assembles_rows_in_order_with_nan_fill():
+    ny, nx = 3, 4
+    rows = {"Counter1": [], "SampleY": []}
+    stream = FakeStream(table_fn=lambda: dict(rows))
+    run = FakeRun(_raster_md(ny, nx))
+    # primary itself IS the stream node in this layout (run["primary"].read())
+    run._primary = stream
+
+    collector = _Collector()
+    streamer = RunStreamer(
+        _factory_for(run), "fake-uid",
+        on_image=collector.on_image, on_progress=collector.on_progress,
+        on_error=collector.on_error, poll_s=0.02, data_field="Counter1",
+    )
+    streamer.start()
+    try:
+        # No rows yet: still get at least one on_image call all-NaN, or none.
+        rows["Counter1"] = [[1.0, 2.0, 3.0, 4.0]]
+        rows["SampleY"] = [-5.0]
+
+        def _first_row_filled():
+            if not collector.images:
+                return False
+            img = collector.images[-1][0]["Counter1"]
+            return not np.any(np.isnan(img[0]))
+
+        assert _wait_until(_first_row_filled)
+        images, extents = collector.images[-1]
+        img = images["Counter1"]
+        assert img.shape == (ny, nx)
+        np.testing.assert_allclose(img[0], [1.0, 2.0, 3.0, 4.0])
+        assert np.all(np.isnan(img[1]))
+        assert np.all(np.isnan(img[2]))
+        assert extents == ([0.0, 10.0], [-5.0, 5.0])
+
+        rows["Counter1"] = [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]]
+        rows["SampleY"] = [-5.0, 0.0]
+
+        def _second_row_filled():
+            if not collector.images:
+                return False
+            img = collector.images[-1][0]["Counter1"]
+            return not np.any(np.isnan(img[1]))
+
+        assert _wait_until(_second_row_filled)
+        img = collector.images[-1][0]["Counter1"]
+        np.testing.assert_allclose(img[1], [5.0, 6.0, 7.0, 8.0])
+        assert np.all(np.isnan(img[2]))
+    finally:
+        streamer.stop()
+
+
+def test_progress_counts_rows_done_and_total():
+    ny, nx = 2, 3
+    rows = {"Counter1": [[1.0, 2.0, 3.0]], "SampleY": [0.0]}
+    stream = FakeStream(table_fn=lambda: dict(rows))
+    run = FakeRun(_raster_md(ny, nx))
+    run._primary = stream
+
+    collector = _Collector()
+    streamer = RunStreamer(
+        _factory_for(run), "fake-uid",
+        on_image=collector.on_image, on_progress=collector.on_progress,
+        on_error=collector.on_error, poll_s=0.02, data_field="Counter1",
+    )
+    streamer.start()
+    try:
+        assert _wait_until(lambda: len(collector.progress) >= 1)
+        done, total = collector.progress[-1]
+        assert total == ny  # single-energy raster: rows_total == ny
+        assert done == 1
+    finally:
+        streamer.stop()
+
+
+def test_stop_halts_polling():
+    stream = FakeStream(table={"Counter1": [], "SampleY": []})
+    run = FakeRun(_raster_md())
+    run._primary = stream
+
+    collector = _Collector()
+    streamer = RunStreamer(
+        _factory_for(run), "fake-uid",
+        on_image=collector.on_image, on_progress=collector.on_progress,
+        on_error=collector.on_error, poll_s=0.02,
+    )
+    streamer.start()
+    _wait_until(lambda: stream.read_count >= 2)
+    streamer.stop()
+    count_at_stop = stream.read_count
+    time.sleep(0.15)
+    assert stream.read_count <= count_at_stop + 1  # no further polls sneak in
+
+
+def test_missing_primary_stream_reports_single_error_no_crash():
+    run = FakeRun(_raster_md(), primary_exc=KeyError("primary"))
+
+    collector = _Collector()
+    streamer = RunStreamer(
+        _factory_for(run), "fake-uid",
+        on_image=collector.on_image, on_progress=collector.on_progress,
+        on_error=collector.on_error, poll_s=0.02,
+    )
+    streamer.start()
+    try:
+        assert _wait_until(lambda: len(collector.errors) >= 1)
+        time.sleep(0.1)
+        assert len(collector.errors) == 1
+        assert not collector.images
+    finally:
+        streamer.stop()
+
+
+def test_malformed_table_reports_single_error_no_crash():
+    stream = FakeStream(table_fn=lambda: {"unexpected": "not a table"})
+    run = FakeRun(_raster_md())
+    run._primary = stream
+
+    collector = _Collector()
+    streamer = RunStreamer(
+        _factory_for(run), "fake-uid",
+        on_image=collector.on_image, on_progress=collector.on_progress,
+        on_error=collector.on_error, poll_s=0.02, data_field="Counter1",
+    )
+    streamer.start()
+    try:
+        assert _wait_until(lambda: len(collector.errors) >= 1)
+        time.sleep(0.1)
+        assert len(collector.errors) == 1
+    finally:
+        streamer.stop()
+
+
+def test_energy_stack_shows_current_slice_modulo_ny():
+    ny, nx, nE = 2, 3, 2
+    start_md = {
+        "plan_name": "stxm_energy_stack",
+        "stxm": {
+            "contract_version": 1,
+            "shape": [nE, ny, nx],
+            "energies": [270.0, 280.0],
+            "x_extent": [0.0, 1.0],
+            "y_extent": [0.0, 1.0],
+        },
+    }
+    # 3 rows so far: iE=0,iy=0 ; iE=0,iy=1 ; iE=1,iy=0 (current slice = energy 1)
+    rows = {
+        "Counter1": [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],
+        "SampleY": [0.0, 1.0, 0.0],
+    }
+    stream = FakeStream(table_fn=lambda: dict(rows))
+    run = FakeRun(start_md)
+    run._primary = stream
+
+    collector = _Collector()
+    streamer = RunStreamer(
+        _factory_for(run), "fake-uid",
+        on_image=collector.on_image, on_progress=collector.on_progress,
+        on_error=collector.on_error, poll_s=0.02, data_field="Counter1",
+    )
+    streamer.start()
+    try:
+        assert _wait_until(lambda: len(collector.progress) >= 1
+                            and collector.progress[-1][0] == 3)
+        img = collector.images[-1][0]["Counter1"]
+        assert img.shape == (ny, nx)
+        np.testing.assert_allclose(img[0], [3.0, 3.0, 3.0])
+        assert np.all(np.isnan(img[1]))
+        done, total = collector.progress[-1]
+        assert done == 3
+        assert total == nE * ny
+    finally:
+        streamer.stop()


### PR DESCRIPTION
Hi David — while prototyping a Lightfall/bluesky integration that wraps the `motor`/`daq` driver objects as ophyd-async devices (in `simulation=True`), I hit three small install/import issues that this PR fixes. None of them change the behavior of the full GUI install on Linux; they just let the driver/controller modules be imported and installed on a host that doesn't have every hardware SDK (or isn't Linux).

**1. Guard optional driver imports** (`drivers/__init__.py`)
`drivers/__init__.py` eagerly imports all ~29 drivers, so one missing optional SDK (epics, pylibftdi, scipy, matplotlib, h5py, ...) makes `import pystxmcontrol.drivers.<anything>` fail entirely. Each import is now wrapped in `try/except` with a short message — the same pattern you already use for the SmarAct and Aerotech drivers. Drivers whose deps are present import normally.

**2. Make the Linux desktop-file install non-fatal / cross-platform** (`setup.py`)
`_install_desktop_file()` ran `update-desktop-database` unconditionally. On non-Linux hosts that raises `FileNotFoundError` (`[WinError 2]` on Windows) during the wheel build, aborting `pip install`. It now skips on non-Linux, only invokes the tool when present (`shutil.which`), and never lets desktop integration fail the build.

**3. Relax the `requires-python` upper cap** (`pyproject.toml`)
`>=3.9,<3.13` → `>=3.9`, so the driver modules install on 3.13/3.14. The cap is driven by the GUI wheels rather than the driver code.

With these three, `pip install --no-deps "pystxmcontrol @ git+<repo>"` installs cleanly on Windows + Python 3.14, and the `xpsMotor`/`xpsController`/`keysight53230A` simulation path imports and runs headless.

Happy to split these into separate PRs, switch the guard messages to `logging`, or adjust anything you'd prefer. Thanks!
